### PR TITLE
Merge: Many new quality of life improvements and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+*.pkl
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/css/widget.css
+++ b/css/widget.css
@@ -3,8 +3,32 @@
  * Distributed under the terms of the MIT license.
  */
 
+.ssv-colors {
+  --ssv-bg-color1: var(--jp-layout-color1);
+  --ssv-bg-color2: var(--jp-layout-color2);
+  --ssv-bg-color3: var(--jp-layout-color3);
+  --ssv-bg-color4: var(--jp-layout-color4);
+
+  --ssv-font-color1: var(--jp-ui-font-color1);
+  --ssv-font-color2: var(--jp-ui-font-color2);
+
+  --ssv-error-color1: var(--jp-error-color1);
+  --ssv-error-color2: var(--jp-error-color2);
+  --ssv-warn-color1: var(--jp-warn-color1);
+}
+
+.ssv-colab-support.ssv-colors {
+  /* We need to change some of the colours here since google colab doesn't seem to support all the jupyter colours. */
+  --ssv-bg-color1: var(--colab-primary-surface-color);
+  --ssv-bg-color2: var(--colab-secondary-surface-color);
+  --ssv-bg-color3: var(--colab-highlighted-surface-color);
+  --ssv-bg-color4: var(--colab-border-color);
+
+  --ssv-font-color2: var(--colab-icon-color);
+}
+
 .ssv-render-widget {
-  background-color: var(--jp-layout-color1); /* #101515;*/
+  background-color: var(--ssv-bg-color1); /* #101515;*/
   padding: 2px;
 }
 
@@ -14,8 +38,8 @@
 
 .ssv-status-bar {
   padding: 4px;
-  background-color: var(--jp-layout-color2); /* #203030;*/
-  color: var(--jp-ui-font-color1);
+  background-color: var(--ssv-bg-color2); /* #203030;*/
+  color: var(--ssv-font-color1);
   display: flex;
   align-items: center;
 }
@@ -26,7 +50,7 @@
 }
 
 .ssv-icon {
-  fill: var(--jp-ui-font-color1);
+  fill: var(--ssv-font-color1);
   stroke-width: 0;
 }
 
@@ -35,7 +59,7 @@
 }
 
 .ssv-status-disconnected {
-  color: var(--jp-error-color2);
+  color: var(--ssv-error-color2);
 }
 
 .ssv-log {
@@ -43,25 +67,25 @@
   max-height: 20rem;
   margin: 10px 0 10px 20px;
   overflow: auto;
-  color: var(--jp-ui-font-color2);
+  color: var(--ssv-font-color2);
   display: none;
   /*white-space-collapse: preserve;*/
 }
 
 .ssv-log-debug {
-  color: var(--jp-ui-font-color2);
+  color: var(--ssv-font-color2);
 }
 
 .ssv-log-info {
-  color: var(--jp-ui-font-color1);
+  color: var(--ssv-font-color1);
 }
 
 .ssv-log-warn {
-  color: var(--jp-warn-color1);
+  color: var(--ssv-warn-color1);
 }
 
 .ssv-log-error {
-  color: var(--jp-error-color1);
+  color: var(--ssv-error-color1);
 }
 
 .ssv-log.ssv-log-active {
@@ -73,17 +97,17 @@
   padding: 0 0.5rem;
   margin-right: 2px;
   font-family: sans-serif;
-  color: var(--jp-ui-font-color1);
-  background-color: var(--jp-layout-color3);
+  color: var(--ssv-font-color1);
+  background-color: var(--ssv-bg-color3);
   border: 1px solid #ffffff10;
   border-radius: 3px;
   height: 2.4rem;
 }
 
 .ssv-button:hover {
-  background-color: var(--jp-layout-color4);
+  background-color: var(--ssv-bg-color4);
 }
 
 .ssv-button:active {
-  background-color: var(--jp-layout-color2);
+  background-color: var(--ssv-bg-color2);
 }

--- a/examples/additional_examples.ipynb
+++ b/examples/additional_examples.ipynb
@@ -179,28 +179,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "id": "625af88b-d151-4303-b0ac-0c03f82a6dd0",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:pySSV:[pySSV_Render] [WARNING] [ssv_render_process_server] [__render_process_loop] Render process shutting down... (watchdog)\n",
-      "\n",
-      "INFO:pySSV:Render server shut down.\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12d4b4db7a8444eeabcb4d0ee4ddc953",
+       "model_id": "5d0a88e5e5c34ea9a2c8d1e038d0213d",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "SSVRenderWidget(enable_renderdoc=True, status_logs='[pySSV] [INFO] [threading] [run] Render server shut down.\\…"
+       "SSVRenderWidget(enable_renderdoc=True, streaming_mode='jpg')"
       ]
      },
      "metadata": {},

--- a/examples/additional_examples.ipynb
+++ b/examples/additional_examples.ipynb
@@ -1,0 +1,344 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3493ef7e-eed2-410b-b3a2-64f3a165f0b1",
+   "metadata": {},
+   "source": [
+    "# Additional Examples\n",
+    "This notebook contains more advanced examples using pySSV."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a53a5b8c-76f5-4f15-892b-87c4ed1fa4cd",
+   "metadata": {
+    "is_executing": true
+   },
+   "outputs": [],
+   "source": [
+    "# Google colab support\n",
+    "try:\n",
+    "    # Try enabling custom widgets, this will fail silently if we're not in Google Colab\n",
+    "    from google.colab import output\n",
+    "    output.enable_custom_widget_manager()\n",
+    "    # Install pySSV for this session\n",
+    "    %pip install pySSV\n",
+    "except:\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb39abbe-1869-4509-8bb4-bbf44762b5b5",
+   "metadata": {},
+   "source": [
+    "### Video\n",
+    "This example takes advantage of the point cloud shader template to render video in real time. In this case, the video is compressed into a quadtree (this is obviously not a very good compression algorithm for video, but it's easy to encode/decode so it makes for a good demonstration) which is stored in a texture. Each row of the animation texture stores the quadtree for one frame where each pixel is one cell in the quadtree. The way this is implemented means the cells don't strictly need to be part of a quad tree, they just each represent a single square of a given size, colour, and location. \n",
+    "\n",
+    "The video quadtree is created by a separate program the code for which can be found here: https://github.com/space928/badapple-quadtree-encoder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "273fb055-3a5a-4d51-86fc-9b41a61523b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Video file 'badapple_quad.pkl' already exists, using existing version...\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os.path\n",
+    "\n",
+    "# Download the compressed video file from the internet if needed (with the user's permission)\n",
+    "filename = \"badapple_quad.pkl\"\n",
+    "if not os.path.isfile(filename):\n",
+    "    if input(\"Encoded video file not found! Do you want to download it now (yes/no)?\")[0] == \"y\":\n",
+    "        url = \"https://github.com/space928/badapple-quadtree-encoder/releases/download/0.1.0/badapple_quad.pkl\"\n",
+    "        import urllib.request\n",
+    "        try:\n",
+    "            print(\"Downloading...\")\n",
+    "            urllib.request.urlretrieve(url, filename)\n",
+    "            print(\"Successfully downloaded encoded video file!\")\n",
+    "        except Error as e:\n",
+    "            print(f\"Failed to download video: {e}\")\n",
+    "else:\n",
+    "    print(f\"Video file '{filename}' already exists, using existing version...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fdfeeee4-d0cd-4bca-99c6-1936b7b33136",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:pySSV:[pySSV_Render] [WARNING] [ssv_render_process_server] [__render_process_loop] Render process shutting down... (watchdog)\n",
+      "\n",
+      "INFO:pySSV:Render server shut down.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded animation! Animation has shape:(4603, 6569, 4)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "02410c52f3de47cfa5c0bd8497f72ce0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SSVRenderWidget(enable_renderdoc=True, status_logs='[pySSV] [INFO] [threading] [run] Render server shut down.\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pySSV as ssv\n",
+    "import numpy as np\n",
+    "import pickle as pkl\n",
+    "\n",
+    "canvas5 = ssv.canvas(use_renderdoc=True)\n",
+    "with open(\"badapple_quad.pkl\", \"rb\") as f:\n",
+    "    anim, frame_lengths = pkl.load(f)\n",
+    "    print(f\"Loaded animation! Animation has shape:{anim.shape}\")\n",
+    "    \n",
+    "canvas5.main_render_buffer.full_screen_vertex_buffer.update_vertex_buffer(np.zeros((anim.shape[0]*6), dtype=np.float32))\n",
+    "\n",
+    "anim = np.swapaxes(anim, 0, 1)\n",
+    "# Dcelare textures, make sure that these textures as treated as ints instead of floats\n",
+    "anim_tex = canvas5.texture(anim, \"uAnimTex\", treat_as_normalized_integer=False)\n",
+    "frame_lengths_tex = canvas5.texture(frame_lengths, \"uFrameLengthsTex\", treat_as_normalized_integer=False)\n",
+    "# Setup texture samplers\n",
+    "anim_tex.repeat_x, anim_tex.repeat_y = False, False\n",
+    "anim_tex.linear_filtering = False\n",
+    "frame_lengths_tex.repeat_x, frame_lengths_tex.repeat_y = False, False\n",
+    "frame_lengths_tex.linear_filtering = False\n",
+    "\n",
+    "canvas5.shader(\"\"\"\n",
+    "#pragma SSV point_cloud mainPoint --non_square_points\n",
+    "// These are automatically declared by the preprocessor\n",
+    "//uniform isampler2D uAnimTex;\n",
+    "//uniform isampler2D uFrameLengthsTex;\n",
+    "VertexOutput mainPoint()\n",
+    "{\n",
+    "    VertexOutput o;\n",
+    "    // Synchronise the playback to the time uniform, 30 FPS\n",
+    "    int frame = int(uTime*30.-20.);\n",
+    "    \n",
+    "    int frameLen = texelFetch(uFrameLengthsTex, ivec2(0, frame), 0).r;\n",
+    "    if(gl_VertexID > frameLen) \n",
+    "    {\n",
+    "        // Early out for verts not needed in this frame; no geometry will be generated for these as the size is set to 0\n",
+    "        o.size = vec2(0.);\n",
+    "        return o;\n",
+    "    }\n",
+    "    // This contains the data for the current quad to rendered (value (0-255), x (pixels), y (pixels), subdivision (0-n))\n",
+    "    ivec4 quad = texelFetch(uAnimTex, ivec2(gl_VertexID, frame), 0);\n",
+    "    // The size is determined by the subdivision level of the cell in the quad tree. \n",
+    "    o.size = vec2(1./pow(2., quad.w-0.1));\n",
+    "    if(quad.w == 0)\n",
+    "        o.size = vec2(0.);\n",
+    "    vec4 pos = vec4(float(quad.z)/480., 1.-float(quad.y)/360., 0., 1.);\n",
+    "    pos.xy += o.size/vec2(2., -2.);  // Centre the point\n",
+    "    pos = pos*2.-1.;  // To clip space (-1 to 1)\n",
+    "    pos += vec4(in_vert, 0.)*1e-8;  // If in_vert is not used, the shader compiler optimises it out which makes OpenGL unhappy; this may be fixed in the future\n",
+    "    o.position = pos;\n",
+    "    o.color = vec4(vec3(float(quad.x)/255.0)+in_color, 1.0);\n",
+    "    return o;\n",
+    "}\n",
+    "\"\"\")\n",
+    "canvas5.run(stream_quality=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7db72da5-cf90-4204-ba6a-738d1cab8ca0",
+   "metadata": {},
+   "source": [
+    "### Geometry shaders\n",
+    "This shader demonstrates the use of custom geometry shaders to render a vector field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "625af88b-d151-4303-b0ac-0c03f82a6dd0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:pySSV:[pySSV_Render] [WARNING] [ssv_render_process_server] [__render_process_loop] Render process shutting down... (watchdog)\n",
+      "\n",
+      "INFO:pySSV:Render server shut down.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "12d4b4db7a8444eeabcb4d0ee4ddc953",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "SSVRenderWidget(enable_renderdoc=True, status_logs='[pySSV] [INFO] [threading] [run] Render server shut down.\\…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pySSV as ssv\n",
+    "import numpy as np\n",
+    "\n",
+    "# Generate some points\n",
+    "def generate_points():\n",
+    "    width, depth = 64, 64\n",
+    "    scale = 3\n",
+    "    v_scale = 0.5\n",
+    "    f = 0.01\n",
+    "    verts = np.zeros((width, depth, 9), dtype='f4')\n",
+    "    for z in range(depth):\n",
+    "        for x in range(width):\n",
+    "            dx = width/2 - x\n",
+    "            dz = depth/2 - z\n",
+    "            y = np.sin((dx*dx+dz*dz)*f) * v_scale\n",
+    "            # Pos\n",
+    "            verts[z, x, :3] = [x/width * scale, y, z/depth * scale]\n",
+    "            # Colour\n",
+    "            verts[z, x, 3:6] = [y/v_scale, abs(y/v_scale), np.sin(y/v_scale*10.)*0.5+0.5]\n",
+    "            # Direction\n",
+    "            verts[z, x, 6:9] = [dx/width, 0.1, dz/depth]\n",
+    "            \n",
+    "    return verts.flatten()\n",
+    "\n",
+    "canvas5 = ssv.canvas(use_renderdoc=True)\n",
+    "# Set the contents of default vertex buffer on the main pass (normally used for full-screen shaders, but in this case hijacked for this example)\n",
+    "canvas5.main_render_buffer.full_screen_vertex_buffer.update_vertex_buffer(generate_points(), (\"in_vert\", \"in_color\", \"in_dir\"))\n",
+    "canvas5.main_camera.target_pos = np.array((1.5, 0, 1.5))\n",
+    "#print(canvas5.dbg_preprocess_shader(\"\"\"\n",
+    "canvas5.shader(\"\"\"\n",
+    "#pragma SSV geometry mainPoint mainGeo --vertex_output_struct VertexOutput --geo_max_vertices 7 --custom_vertex_input\n",
+    "struct VertexOutput {\n",
+    "    vec4 position;\n",
+    "    vec4 color;\n",
+    "    vec3 dir;\n",
+    "    float size;\n",
+    "};\n",
+    "\n",
+    "#ifdef SHADER_STAGE_VERTEX\n",
+    "in vec3 in_vert;\n",
+    "in vec3 in_color;\n",
+    "in vec3 in_dir;\n",
+    "\n",
+    "VertexOutput mainPoint()\n",
+    "{\n",
+    "    VertexOutput o;\n",
+    "    vec4 pos = vec4(in_vert, 1.0);\n",
+    "    //pos = uViewMat * pos;\n",
+    "    //pos = uProjMat * pos;\n",
+    "    o.position = pos;\n",
+    "    o.color = vec4(in_color, 1.);\n",
+    "    o.size = 30.0/uResolution.x;\n",
+    "    o.dir = normalize(in_dir);\n",
+    "    return o;\n",
+    "}\n",
+    "#endif\n",
+    "\n",
+    "#ifdef SHADER_STAGE_GEOMETRY\n",
+    "void mainGeo(VertexOutput i) {\n",
+    "    vec4 position = i.position;\n",
+    "    float size = i.size;\n",
+    "    // This output variable is defined by the template and must be written to before the first EmitVertex() call to take effect\n",
+    "    out_color = i.color;\n",
+    "    vec3 fwd = normalize((uViewMat * vec4(0., 0., 1., 0.)).xyz);\n",
+    "    vec3 perp = normalize(cross(i.dir, fwd));\n",
+    "    vec4 aspect_ratio = vec4(1., uResolution.x/uResolution.y, 1., 1.);\n",
+    "    float baseWidth = 0.05;\n",
+    "    float headWidth = 0.2;\n",
+    "    float headLength = 0.4;\n",
+    "    // Now we draw an arrow\n",
+    "    // Base\n",
+    "    out_color = vec4(0.,0.,0.,1.);\n",
+    "    gl_Position = position + size * vec4(perp*baseWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    gl_Position = position + size * vec4(-perp*baseWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    out_color = i.color;\n",
+    "    gl_Position = position + size * vec4(i.dir + perp*baseWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    gl_Position = position + size * vec4(i.dir - perp*baseWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    EndPrimitive();\n",
+    "    // Head\n",
+    "    gl_Position = position + size * vec4(i.dir + perp*headWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    gl_Position = position + size * vec4(i.dir + -perp*headWidth, 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    gl_Position = position + size * vec4(i.dir * (1.+headLength), 0.0) * aspect_ratio;\n",
+    "    gl_Position = uProjMat * uViewMat * gl_Position;\n",
+    "    EmitVertex();\n",
+    "    EndPrimitive();\n",
+    "}\n",
+    "#endif\n",
+    "\"\"\")#)\n",
+    "canvas5.run(stream_quality=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4f8a8c7-8b54-4186-b00c-c0116e53343d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -12,13 +12,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
-    "is_executing": true,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "is_executing": true
    },
    "outputs": [],
    "source": [
@@ -35,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-12-02T10:19:29.482250800Z",
@@ -52,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -80,13 +77,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d0e73c6e5d646b0a2ffc21e53cba406",
+       "model_id": "cc72b88be8714693a6582882829c56d3",
        "version_major": 2,
        "version_minor": 0
       },
@@ -106,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 5,
    "metadata": {
     "tags": []
    },
@@ -118,10 +115,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "### Mouse input\n",
@@ -130,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 6,
    "metadata": {
     "tags": []
    },
@@ -138,7 +132,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "964b47e2a2b642619133963da6b5bd28",
+       "model_id": "3526be3f1e7343e6b03eacd22cf86ca5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -178,10 +172,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
-    "jupyter": {
-     "outputs_hidden": false
-    }
+    "collapsed": false
    },
    "source": [
     "Here's a more complex shader taken almost directly from ShaderToy."
@@ -189,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 7,
    "metadata": {
     "is_executing": true,
     "tags": []
@@ -198,7 +189,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "77ac1949ffaa4eae9a2f1163ad29514e",
+       "model_id": "8f199d1563fb4f66a2fb4db363efd1e2",
        "version_major": 2,
        "version_minor": 0
       },
@@ -308,13 +299,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f8ce097758204c608ef7afb2f1fd7c7a",
+       "model_id": "e6d53d6c8e784ec1bc1a86d3a4c66fba",
        "version_major": 2,
        "version_minor": 0
       },
@@ -361,13 +352,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c955d4773f3b45ddb36520a5cdc39a4a",
+       "model_id": "218cffc458c34366bb9ea1e6a43a958e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -383,7 +374,7 @@
     "import pySSV as ssv\n",
     "import numpy as np\n",
     "\n",
-    "canvas4 = ssv.canvas()\n",
+    "canvas4 = ssv.canvas(use_renderdoc=True)\n",
     "# Create a new render buffer on this canvas\n",
     "rb = canvas4.render_buffer(size=(640, 480), name=\"renderBuffer1\")\n",
     "\n",
@@ -445,13 +436,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66c83bbc26274a1ca730bff063d386f8",
+       "model_id": "d96778bf81a748a0831168516d68682c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -512,13 +503,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df20f504c26c4c49b564d331eee8ec4d",
+       "model_id": "5c05338d289f4a05947e90095241039c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -571,7 +562,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +578,7 @@
     "            dx = width/2 - x\n",
     "            dz = depth/2 - z\n",
     "            y = np.sin((dx*dx+dz*dz)*f) * v_scale\n",
-    "            verts[z, x, :3] = [x/width * scale, y - 1.5, z/depth * scale]\n",
+    "            verts[z, x, :3] = [x/width * scale, y, z/depth * scale]\n",
     "            verts[z, x, 3:6] = [y/v_scale, abs(y/v_scale), np.sin(y/v_scale*10.)*0.5+0.5]\n",
     "            \n",
     "    return verts.flatten()\n"
@@ -595,18 +586,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "93ab672ca9d24728b199e35bd4c8c169",
+       "model_id": "e7da50f1da8443d19f63b1681c9387de",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "SSVRenderWidget(streaming_mode='jpg')"
+       "SSVRenderWidget(enable_renderdoc=True, streaming_mode='jpg')"
       ]
      },
      "metadata": {},
@@ -617,9 +608,10 @@
     "import pySSV as ssv\n",
     "import numpy as np\n",
     "\n",
-    "canvas5 = ssv.canvas()\n",
+    "canvas5 = ssv.canvas(use_renderdoc=True)\n",
     "# Set the contents of default vertex buffer on the main pass (normally used for full-screen shaders, but in this case hijacked for this example)\n",
     "canvas5.main_render_buffer.full_screen_vertex_buffer.update_vertex_buffer(generate_points())\n",
+    "canvas5.main_camera.target_pos = np.array((1.5, 0, 1.5))\n",
     "canvas5.shader(\"\"\"\n",
     "#pragma SSV point_cloud mainPoint\n",
     "VertexOutput mainPoint()\n",
@@ -654,13 +646,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "97d2fc52e93848a4864c2734209f68b5",
+       "model_id": "7fda9756acf94f64b0fd99a71ddf0264",
        "version_major": 2,
        "version_minor": 0
       },
@@ -676,10 +668,24 @@
     "import pySSV as ssv\n",
     "import numpy as np\n",
     "\n",
-    "canvas5 = ssv.canvas(use_renderdoc=False)\n",
+    "canvas5 = ssv.canvas(use_renderdoc=True)\n",
+    "# Here we generate a simple 3x3 single component texture. By default, pySSV will attempt to treat this as a 3x1 \n",
+    "# texture with 3 components (since the height is less than the maximum number of components in a texture (4)), as\n",
+    "# such we use the `force_2d` parameter to tell pySSV to treat the 2nd dimension of the array as height instead of \n",
+    "# components.\n",
+    "texture = canvas5.texture(np.array([\n",
+    "    [0., 0.1, 0.2],\n",
+    "    [0.3, 0.4, 0.5],\n",
+    "    [0.6, 0.7, 0.8]\n",
+    "], dtype=np.float16), \"uTexture1\", force_2d=True)\n",
+    "# texture.linear_filtering = False\n",
+    "texture.repeat_x, texture.repeat_y = False, False\n",
+    "texture.linear_filtering = False\n",
     "canvas5.shader(\"\"\"\n",
     "#pragma SSV pixel mainImage\n",
-    "uniform sampler2D uTexture1;\n",
+    "// Provided that the texture is declared on the canvas *before* the shader is, then it's uniform will be \n",
+    "// automatically declared in the shader by the preprocessor.\n",
+    "//uniform sampler2D uTexture1;\n",
     "vec4 mainImage(in vec2 fragCoord)\n",
     "{\n",
     "    // Normalized pixel coordinates (from 0 t 1)\n",
@@ -693,17 +699,6 @@
     "    return vec4(vec3(col), 1.0);\n",
     "}\n",
     "\"\"\")\n",
-    "# Here we generate a simple 3x3 single component texture. By default, pySSV will attempt to treat this as a 3x1 \n",
-    "# texture with 3 components (since the height is less than the maximum number of components in a texture (4)), as\n",
-    "# such we use the `force_2d` parameter to tell pySSV to treat the 2nd dimension of the array as height instead of \n",
-    "# components.\n",
-    "texture = canvas5.texture(np.array([\n",
-    "    [0., 0.1, 0.2],\n",
-    "    [0.3, 0.4, 0.5],\n",
-    "    [0.6, 0.7, 0.8]\n",
-    "], dtype=np.float16), \"uTexture1\", force_2d=True)\n",
-    "# texture.linear_filtering = False\n",
-    "texture.repeat_x, texture.repeat_y = False, False\n",
     "canvas5.run()"
    ]
   },
@@ -749,16 +744,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "#####################################\n",
-      "##########  Vertex Shader  ##########\n",
-      "#####################################\n",
+      "/************************************************************\n",
+      " *         pySSV Shader Preprocessor version: 0.4.1         *\n",
+      " ************************************************************/\n",
+      "\n",
+      "////////////////////////////////////////\n",
+      "//           VERTEX_SHADER            //\n",
+      "////////////////////////////////////////\n",
+      "\n",
       "#version 420\n",
       "#extension GL_ARB_shading_language_include : require\n",
       "#line 3 \"global_uniforms.glsl\"\n",
@@ -773,19 +773,22 @@
       "#line 21 \"global_uniforms.glsl\"\n",
       "uniform sampler2D main_render_buffer;;\n",
       "#line 14 \"template_pixel.glsl\"\n",
-      "in vec2 in_vert;\n",
-      "in vec3 in_color;\n",
-      "out vec3 color;\n",
-      "out vec2 position;\n",
+      "layout(location = 0) in vec2 in_vert;\n",
+      "layout(location = 1) in vec3 in_color;\n",
+      "layout(location = 0) out vec3 color;\n",
+      "layout(location = 1) out vec2 position;\n",
       "void main() {\n",
       "    gl_Position = vec4(in_vert, 0.0, 1.0);\n",
       "    color = in_color;\n",
       "    position = in_vert*0.5+0.5;\n",
       "}\n",
       "\n",
-      "#####################################\n",
-      "########## Fragment Shader ##########\n",
-      "#####################################\n",
+      "\n",
+      "\n",
+      "////////////////////////////////////////\n",
+      "//          FRAGMENT_SHADER           //\n",
+      "////////////////////////////////////////\n",
+      "\n",
       "#version 420\n",
       "#extension GL_ARB_shading_language_include : require\n",
       "#line 3 \"global_uniforms.glsl\"\n",
@@ -801,8 +804,8 @@
       "uniform sampler2D main_render_buffer;;\n",
       "#line 27 \"template_pixel.glsl\"\n",
       "out vec4 fragColor;\n",
-      "in vec3 color;\n",
-      "in vec2 position;\n",
+      "layout(location = 0) in vec3 color;\n",
+      "layout(location = 1) in vec2 position;\n",
       "#line 3 \"TEMPLATE_DATA\"\n",
       "vec4 mainImage( in vec2 fragCoord )\n",
       "{\n",
@@ -822,10 +825,8 @@
       "}\n",
       "#line 33 \"template_pixel.glsl\"\n",
       "void main() {\n",
-      "\n",
-      "    fragColor = mainImage(position * uResolution.xy) + vec4(color, 1.0)*1e-6;\n",
-      "}\n",
-      "\n"
+      "    fragColor = mainImage(position * uResolution.xy);\n",
+      "}\n"
      ]
     }
    ],
@@ -851,14 +852,7 @@
     "    return vec4(vec3(col), 1.0);\n",
     "}\n",
     "\"\"\")\n",
-    "print(\"#####################################\")\n",
-    "print(\"##########  Vertex Shader  ##########\")\n",
-    "print(\"#####################################\")\n",
-    "print(shader[\"vertex_shader\"])\n",
-    "print(\"#####################################\")\n",
-    "print(\"########## Fragment Shader ##########\")\n",
-    "print(\"#####################################\")\n",
-    "print(shader[\"fragment_shader\"])"
+    "print(shader)"
    ]
   },
   {
@@ -953,8 +947,7 @@
       "                        How the distance field should be rendered. Check the documentation for more information about\n",
       "                        each mode. (default: SOLID)\n",
       "\n",
-      "author: Thomas Mathieson\n",
-      "\n"
+      "author: Thomas Mathieson\n"
      ]
     }
    ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "py-ssv",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "description": "Leverage the power of shaders for scientific visualisation in Jupyter",
     "keywords": [
         "jupyter",

--- a/pySSV/__init__.py
+++ b/pySSV/__init__.py
@@ -36,7 +36,7 @@ def _jupyter_nbextension_paths():
 # Various factory methods
 
 def canvas(size: Optional[tuple[int, int]] = (640, 480), backend: str = "opengl", standalone: bool = False,
-           target_framerate: int = 60, use_renderdoc: bool = False):
+           target_framerate: int = 60, use_renderdoc: bool = False, supports_line_directives: Optional[bool] = None):
     """
     Creates a new ``SSVCanvas`` which contains the render widget and manages the render context.
 
@@ -47,6 +47,10 @@ def canvas(size: Optional[tuple[int, int]] = (640, 480), backend: str = "opengl"
     :param target_framerate: the default framerate to target when running.
     :param use_renderdoc: optionally, an instance of the Renderdoc in-app api to provide support for frame
                            capturing and analysis in renderdoc.
+    :param supports_line_directives: whether the shader compiler supports ``#line`` directives (Nvidia GPUs only). Set
+                                     to ``None`` for automatic detection. If you get
+                                     'extension not supported: GL_ARB_shading_language_include' errors, set this to
+                                     ``False``.
     """
 
-    return SSVCanvas(size, backend, standalone, target_framerate, use_renderdoc)
+    return SSVCanvas(size, backend, standalone, target_framerate, use_renderdoc, supports_line_directives)

--- a/pySSV/shaders/compat.glsl
+++ b/pySSV/shaders/compat.glsl
@@ -7,11 +7,13 @@
 // directive is the first in the file.
 #pragma PreventLine true
 _GL_VERSION
-#extension GL_ARB_shading_language_include : require
 #ifdef _GL_ADDITIONAL_EXTENSIONS
 _GL_ADDITIONAL_EXTENSIONS
 #endif
+#ifdef _GL_SUPPORTS_LINE_DIRECTIVES
+#extension GL_ARB_shading_language_include : require
 #pragma PreventLine false
+#endif // _GL_SUPPORTS_LINE_DIRECTIVES
 #endif // _GL_VERSION
 
 #ifdef _GL_PRECISION

--- a/pySSV/shaders/template_geometry.glsl
+++ b/pySSV/shaders/template_geometry.glsl
@@ -1,0 +1,110 @@
+//  Copyright (c) 2023 Thomas Mathieson.
+//  Distributed under the terms of the MIT license.
+#pragma SSVTemplate define point_cloud --author "Thomas Mathieson" --description "Allows the use of a geometry shader to generate triangles from vertices (treated as points)."
+#pragma SSVTemplate stage vertex
+#pragma SSVTemplate stage geometry
+#pragma SSVTemplate stage fragment
+#pragma SSVTemplate input_primitive POINTS
+#pragma SSVTemplate arg entrypoint_vert -d "The name of the entrypoint function to vertex the shader." --default default_vert
+#pragma SSVTemplate arg entrypoint_geo -d "The name of the entrypoint function to geometry the shader." --default default_geo
+//#pragma SSVTemplate arg _vertex_input_struct -d "The name of the struct containing data to be input to the vertex stage of the shader." --default DefaultVertexInput
+#pragma SSVTemplate arg _vertex_output_struct -d "The name of the struct containing data to be transferred from the vertex stage to the geometry stage." --default DefaultVertexOutput
+#pragma SSVTemplate arg _geo_max_vertices -d "The maximum number of vertices which can be output be the geometry stage per input vertex. Must be a constant." --default 4
+#pragma SSVTemplate arg _custom_vertex_input -d "When this flag is passed, the default vertex input attributes are not created and must be declared by the user." --action store_true
+
+// Include any default includes we think the user might want
+#include "compat.glsl"
+#include "global_uniforms.glsl"
+
+
+#ifdef T_VERTEX_OUTPUT_STRUCT_ISDEFAULT
+struct DefaultVertexOutput {
+    vec4 position;
+    vec4 color;
+    float size;
+};
+#endif // T_VERTEX_OUTPUT_STRUCT_ISDEFAULT
+
+#ifdef SHADER_STAGE_VERTEX
+#ifndef T_CUSTOM_VERTEX_INPUT
+// By using an explicit layout binding, we prevent the compiler from stripping the input attributes.
+layout(location = 0) in vec4 in_vert;
+layout(location = 1) in vec4 in_color;
+#endif // T_CUSTOM_VERTEX_INPUT
+#endif // SHADER_STAGE_VERTEX
+
+#ifdef SHADER_STAGE_GEOMETRY
+layout(location = 0) out vec4 out_color;
+#endif // SHADER_STAGE_GEOMETRY
+
+#include "TEMPLATE_DATA"
+
+#ifdef SHADER_STAGE_VERTEX
+layout(location = 0) out T_VERTEX_OUTPUT_STRUCT v_out;
+
+#ifndef T_CUSTOM_VERTEX_INPUT
+T_VERTEX_OUTPUT_STRUCT default_vert() {
+    T_VERTEX_OUTPUT_STRUCT o;
+    vec4 pos = vec4(in_vert, 1.0);
+    pos = uViewMat * pos;
+    pos = uProjMat * pos;
+    o.position = pos;
+    o.color = vec4(in_color, 1.);
+    o.size = 10.0/uResolution.x;
+    return o;
+}
+#else
+#ifdef T_ENTRYPOINT_VERT_ISDEFAULT
+#error Using custom vertex input attributes with the default vertex shader is not supported. Make sure to define 'entrypoint_vert' in your shader!
+#endif // T_ENTRYPOINT_VERT_ISDEFAULT
+T_VERTEX_OUTPUT_STRUCT default_vert() {
+    T_VERTEX_OUTPUT_STRUCT o;
+    return o;
+}
+#endif // T_CUSTOM_VERTEX_INPUT
+
+void main() {
+    v_out = T_ENTRYPOINT_VERT();
+}
+#endif //SHADER_STAGE_VERTEX
+
+
+#ifdef SHADER_STAGE_GEOMETRY
+layout(points) in;
+layout(triangle_strip, max_vertices=T_GEO_MAX_VERTICES) out;
+
+layout(location = 0) in T_VERTEX_OUTPUT_STRUCT v_out[];
+
+#ifdef T_ENTRYPOINT_VERT_ISDEFAULT
+void default_geo(T_VERTEX_OUTPUT_STRUCT i) {
+    vec4 position = i.position;
+    float size = i.size;
+    out_color = i.color;
+    vec4 aspect_ratio = vec4(1., uResolution.x/uResolution.y, 1., 1.);
+    gl_Position = position + size * vec4(-1., -1., 0.0, 0.0) * aspect_ratio;
+    EmitVertex();
+    gl_Position = position + size * vec4(1., -1., 0.0, 0.0) * aspect_ratio;
+    EmitVertex();
+    gl_Position = position + size * vec4(-1., 1., 0.0, 0.0) * aspect_ratio;
+    EmitVertex();
+    gl_Position = position + size * vec4(1., 1., 0.0, 0.0) * aspect_ratio;
+    EmitVertex();
+    EndPrimitive();
+}
+#endif //T_ENTRYPOINT_VERT_ISDEFAULT
+
+void main() {
+    out_color = vec4(1., 0.5, 1., 1.);
+    T_ENTRYPOINT_GEO(v_out[0]);
+}
+#endif //SHADER_STAGE_GEOMETRY
+
+
+#ifdef SHADER_STAGE_FRAGMENT
+out vec4 fragColor;
+layout(location = 0) in vec4 out_color;
+
+void main() {
+    fragColor = out_color;
+}
+#endif //SHADER_STAGE_FRAGMENT

--- a/pySSV/shaders/template_pixel.glsl
+++ b/pySSV/shaders/template_pixel.glsl
@@ -11,10 +11,10 @@
 
 
 #ifdef SHADER_STAGE_VERTEX
-in vec2 in_vert;
-in vec3 in_color;
-out vec3 color;
-out vec2 position;
+layout(location = 0) in vec2 in_vert;
+layout(location = 1) in vec3 in_color;
+layout(location = 0) out vec3 color;
+layout(location = 1) out vec2 position;
 void main() {
     gl_Position = vec4(in_vert, 0.0, 1.0);
     color = in_color;
@@ -25,13 +25,12 @@ void main() {
 
 #ifdef SHADER_STAGE_FRAGMENT
 out vec4 fragColor;
-in vec3 color;
-in vec2 position;
+layout(location = 0) in vec3 color;
+layout(location = 1) in vec2 position;
 
 #include "TEMPLATE_DATA"
 
 void main() {
-    // Not using the color attribute causes the compiler to strip it and confuses modernGL.
-    fragColor = T_ENTRYPOINT(position * uResolution.xy) + vec4(color, 1.0)*1e-6;
+    fragColor = T_ENTRYPOINT(position * uResolution.xy);
 }
 #endif //SHADER_STAGE_FRAGMENT

--- a/pySSV/shaders/template_point_cloud.glsl
+++ b/pySSV/shaders/template_point_cloud.glsl
@@ -6,6 +6,7 @@
 #pragma SSVTemplate stage fragment
 #pragma SSVTemplate input_primitive POINTS
 #pragma SSVTemplate arg entrypoint -d "The name of the entrypoint function to the shader." --default default_vert
+#pragma SSVTemplate arg _non_square_points -d "When specified 'size' parameter of VertexOutput struct takes a vec2." --action store_true
 
 // Include any default includes we think the user might want
 #include "compat.glsl"
@@ -13,13 +14,21 @@
 
 
 #ifdef SHADER_STAGE_VERTEX
-in vec3 in_vert;
-in vec3 in_color;
-out vec4 color;
+// These are specified with an explicit layout specifier to prevent compiler stripping
+layout(location = 0) in vec3 in_vert;
+layout(location = 1) in vec3 in_color;
+layout(location = 0) out vec4 _color;
+#ifdef T_NON_SQUARE_POINTS
+layout(location = 1) out vec2 _size;
+#endif
 
 struct VertexOutput {
     vec4 position;
+    #ifdef T_NON_SQUARE_POINTS
+    vec2 size;
+    #else
     float size;
+    #endif
     vec4 color;
 };
 
@@ -32,15 +41,23 @@ VertexOutput default_vert() {
     pos = uProjMat * pos;
     o.position = pos;
     o.color = vec4(in_color, 1.);
+    #ifdef T_NON_SQUARE_POINTS
+    o.size = vec2(10.0/uResolution.x);
+    #else
     o.size = 10.0/uResolution.x;
+    #endif
     return o;
 }
 
 void main() {
     VertexOutput vOut = T_ENTRYPOINT();
     gl_Position = vOut.position;
-    color = vOut.color;
+    _color = vOut.color;
+    #ifdef T_NON_SQUARE_POINTS
+    _size = vOut.size;
+    #else
     gl_PointSize = vOut.size;
+    #endif
 }
 #endif //SHADER_STAGE_VERTEX
 
@@ -49,14 +66,30 @@ void main() {
 layout(points) in;
 layout(triangle_strip, max_vertices=4) out;
 
-in vec4 color[];
-out vec4 out_color;
+layout(location = 0) in vec4 _color[];
+#ifdef T_NON_SQUARE_POINTS
+layout(location = 1) in vec2 _size[];
+#endif
+layout(location = 0) out vec4 out_color;
 
 void main() {
     vec4 position = gl_in[0].gl_Position;
+    #ifdef T_NON_SQUARE_POINTS
+    if(_size[0] == vec2(0.)) {
+        EndPrimitive();
+        return;
+    }
+    vec4 size = vec4(_size[0], 1., 1.);
+    vec4 aspect_ratio = vec4(1.);
+    #else
+    if(gl_in[0].gl_PointSize == 0.) {
+        EndPrimitive();
+        return;
+    }
     float size = gl_in[0].gl_PointSize;
-    out_color = color[0];
     vec4 aspect_ratio = vec4(1., uResolution.x/uResolution.y, 1., 1.);
+    #endif
+    out_color = _color[0];
     gl_Position = position + size * vec4(-1., -1., 0.0, 0.0) * aspect_ratio;
     EmitVertex();
     gl_Position = position + size * vec4(1., -1., 0.0, 0.0) * aspect_ratio;
@@ -72,9 +105,9 @@ void main() {
 
 #ifdef SHADER_STAGE_FRAGMENT
 out vec4 fragColor;
-in vec4 out_color;
+layout(location = 0) in vec4 out_color;
 
 void main() {
-    fragColor = out_color+vec4(0.5);
+    fragColor = out_color;
 }
 #endif //SHADER_STAGE_FRAGMENT

--- a/pySSV/shaders/template_render_test.glsl
+++ b/pySSV/shaders/template_render_test.glsl
@@ -11,10 +11,10 @@
 #include "global_uniforms.glsl"
 
 #ifdef SHADER_STAGE_VERTEX
-in vec2 in_vert;
-in vec3 in_color;
-out vec3 color;
-out vec2 position;
+layout(location = 0) in vec2 in_vert;
+layout(location = 1) in vec3 in_color;
+layout(location = 0) out vec3 color;
+layout(location = 1) out vec2 position;
 void main() {
     gl_Position = vec4(in_vert, 0.0, 1.0);
     color = in_color;
@@ -25,8 +25,8 @@ void main() {
 
 #ifdef SHADER_STAGE_FRAGMENT
 out vec4 fragColor;
-in vec3 color;
-in vec2 position;
+layout(location = 0) in vec3 color;
+layout(location = 1) in vec2 position;
 
 vec4 mainImage(in vec2 fragCoord)
 {
@@ -40,7 +40,6 @@ vec4 mainImage(in vec2 fragCoord)
 }
 
 void main() {
-    // Not using the color attribute causes the compiler to strip it and confuses modernGL.
-    fragColor = mainImage(position * iResolution.xy) + vec4(color, 1.0)*1e-6;
+    fragColor = mainImage(position * iResolution.xy);
 }
 #endif //SHADER_STAGE_FRAGMENT

--- a/pySSV/shaders/template_sdf.glsl
+++ b/pySSV/shaders/template_sdf.glsl
@@ -23,10 +23,10 @@
 
 
 #ifdef SHADER_STAGE_VERTEX
-in vec2 in_vert;
-in vec3 in_color;
-out vec3 color;
-out vec2 position;
+layout(location = 0) in vec2 in_vert;
+layout(location = 1) in vec3 in_color;
+layout(location = 0) out vec3 color;
+layout(location = 1) out vec2 position;
 void main() {
     gl_Position = vec4(in_vert, 0.0, 1.0);
     color = in_color;
@@ -37,8 +37,8 @@ void main() {
 
 #ifdef SHADER_STAGE_FRAGMENT
 out vec4 fragColor;
-in vec3 color;
-in vec2 position;
+layout(location = 0) in vec3 color;
+layout(location = 1) in vec2 position;
 
 #include "TEMPLATE_DATA"
 
@@ -132,7 +132,6 @@ void main() {
 
     vec3 col = _shadeGBuff(p, nrm, r, t, uv);
 
-    // Not using the color attribute causes the compiler to strip it and confuses modernGL.
-    fragColor = vec4(col, 1.) + vec4(color, 1.0)*1e-10;
+    fragColor = vec4(col, 1.);
 }
 #endif //SHADER_STAGE_FRAGMENT

--- a/pySSV/ssv_camera.py
+++ b/pySSV/ssv_camera.py
@@ -4,8 +4,9 @@ import logging
 import typing
 from enum import Enum
 import numpy as np
-import numpy.typing as npt
 import math
+from abc import ABC, abstractmethod
+from numpy import typing as npt
 
 from .ssv_logging import log
 
@@ -35,20 +36,13 @@ class SSVCamera:
     """The field of view of the camera in degrees."""
     clip_dist: tuple[float, float]
     """The distances of the near and far clipping planes respectively."""
-    move_speed: float
-    """The movement speed of the camera."""
-    pan_speed: float
-    """The panning speed of the camera in radians per pixel of mouse movement."""
     aspect_ratio: float
     """The aspect ratio of the render buffer."""
-
     def __init__(self):
         self.position = np.array([0., 0., 0.])
         self.direction = np.array([0., 0., -1.])
         self.fov = 60
         self.clip_dist = (0.1, 1000.0)
-        self.move_speed = 0.1
-        self.pan_speed = 0.005
         self.aspect_ratio = 1
 
         self._mouse_old_pos = np.array([0., 0.])
@@ -58,6 +52,72 @@ class SSVCamera:
         self._projection_matrix = np.identity(4)
         self._up_vec = np.array([0., 1., 0.])
 
+    @property
+    def view_matrix(self) -> npt.NDArray[float]:
+        """
+        Gets the current view matrix of the camera.
+        """
+        right = np.cross(self.direction, self._up_vec)
+        right /= np.linalg.norm(right)
+        up = np.cross(right, self.direction)
+        up /= np.linalg.norm(up)
+        self._view_matrix = np.identity(4, dtype=np.float32)
+        self._view_matrix[0:3, 0] = right
+        self._view_matrix[0:3, 1] = up
+        self._view_matrix[0:3, 2] = self.direction
+        self._view_matrix = np.array((
+            (1, 0, 0, 0),
+            (0, 1, 0, 0),
+            (0, 0, 1, 0),
+            (-self.position[0], -self.position[1], -self.position[2], 1),
+        ), dtype=np.float32) @ self._view_matrix
+
+        return self._view_matrix
+
+    @property
+    def projection_matrix(self):
+        """
+        Gets the current projection matrix of the camera.
+        """
+        s = 1.0 / math.tan(math.radians(self.fov) / 2.0)
+        s1 = s / self.aspect_ratio
+        self._projection_matrix[0, 0] = s
+        self._projection_matrix[1, 1] = s1
+        self._projection_matrix[2, 2] = self.clip_dist[1] / (self.clip_dist[0] - self.clip_dist[1])
+        self._projection_matrix[2, 3] = -1
+        self._projection_matrix[3, 2] = (self.clip_dist[0] * self.clip_dist[1]) / (self.clip_dist[0] - self.clip_dist[1])
+        self._projection_matrix[3, 3] = 0
+        return self._projection_matrix
+
+
+class SSVCameraController(SSVCamera, ABC):
+    """
+    A simple class representing a camera controller.
+    """
+
+    move_speed: float
+    """The movement speed of the camera."""
+    pan_speed: float
+    """The panning speed of the camera in radians per pixel of mouse movement."""
+
+    def __init__(self):
+        super().__init__()
+        self.move_speed = 0.1
+        self.pan_speed = 0.005
+
+    @abstractmethod
+    def mouse_change(self, mouse_pos: list[int], mouse_down: bool):
+        ...
+
+    @abstractmethod
+    def move(self, direction: MoveDir, distance: float = 1.0):
+        ...
+
+
+class SSVLookCameraController(SSVCameraController):
+    """
+    A camera controller which supports mouse look controls.
+    """
     def mouse_change(self, mouse_pos: list[int], mouse_down: bool):
         """
         Updates the camera with a mouse event.
@@ -72,9 +132,9 @@ class SSVCamera:
             else:
                 self._rotation += (np.array(mouse_pos) - self._mouse_old_pos) * self.pan_speed
                 self._rotation[1] = min(max(self._rotation[1], -math.pi/2), math.pi/2)
-                self.direction[0] = math.sin(self._rotation[0]) * math.cos(self._rotation[1])
+                self.direction[0] = math.cos(self._rotation[0]) * math.cos(self._rotation[1])
                 self.direction[1] = math.sin(self._rotation[1])
-                self.direction[2] = math.cos(self._rotation[0]) * math.cos(self._rotation[1])
+                self.direction[2] = math.sin(self._rotation[0]) * math.cos(self._rotation[1])
                 self._mouse_old_pos[:] = mouse_pos
         else:
             self._mouse_was_pressed = False
@@ -100,33 +160,78 @@ class SSVCamera:
             self.position[2] -= self.move_speed * distance
         # log(f"Moved position: {self.position}", severity=logging.INFO)
 
-    @property
-    def view_matrix(self) -> npt.NDArray[float]:
-        """
-        Gets the current view matrix of the camera.
-        """
-        right = np.cross(self._up_vec, self.direction)
-        right /= np.linalg.norm(right)
-        up = np.cross(self.direction, right)
-        self._view_matrix[0:3, 0] = right
-        self._view_matrix[0:3, 1] = up
-        self._view_matrix[0:3, 2] = self.direction
-        self._view_matrix[3, 0:3] = -self.position
-        # self._view_matrix[0:3, 3] = -self.position
 
-        return self._view_matrix
+class SSVOrbitCameraController(SSVCameraController):
+    """
+    A camera controller which supports orbiting around a given target.
+    """
+    target_pos: npt.NDArray[3]
+    """The point around which to orbit."""
+    orbit_dist: float
+    """The distance from the target position to orbit at."""
 
-    @property
-    def projection_matrix(self):
+    def __init__(self):
+        super().__init__()
+        self.target_pos = np.array([0, 0, 0])
+        self.orbit_dist = 2
+
+    def _update_direction_position(self):
+        self.direction[0] = math.cos(self._rotation[0]) * math.cos(self._rotation[1])
+        self.direction[1] = math.sin(self._rotation[1])
+        self.direction[2] = math.sin(self._rotation[0]) * math.cos(self._rotation[1])
+
+        self.position[:] = self.target_pos + self.direction * self.orbit_dist
+
+    def mouse_change(self, mouse_pos: list[int], mouse_down: bool):
         """
-        Gets the current projection matrix of the camera.
+        Updates the camera with a mouse event.
+
+        :param mouse_pos: the new mouse position.
+        :param mouse_down: whether the mouse button is pressed.
         """
-        s = 1.0 / math.tan(math.radians(self.fov) / 2.0)
-        s1 = s / self.aspect_ratio
-        self._projection_matrix[0, 0] = s
-        self._projection_matrix[1, 1] = s1
-        self._projection_matrix[2, 2] = self.clip_dist[1] / (self.clip_dist[0] - self.clip_dist[1])
-        self._projection_matrix[2, 3] = -1
-        self._projection_matrix[3, 2] = (self.clip_dist[0] * self.clip_dist[1]) / (self.clip_dist[0] - self.clip_dist[1])
-        self._projection_matrix[3, 3] = 0
-        return self._projection_matrix
+        if mouse_down:
+            if not self._mouse_was_pressed:
+                self._mouse_was_pressed = True
+                self._mouse_old_pos[:] = mouse_pos
+            else:
+                self._rotation -= (np.array(mouse_pos) - self._mouse_old_pos) * self.pan_speed
+                self._rotation[1] = min(max(self._rotation[1], -math.pi/2), math.pi/2)
+
+                self._update_direction_position()
+
+                # log(f"view_mat=\n{np.transpose(self.view_matrix)}", severity=logging.INFO)
+
+                self._mouse_old_pos[:] = mouse_pos
+        else:
+            self._mouse_was_pressed = False
+
+    def zoom(self, distance: float):
+        """
+        Updates the orbit distance with a zoom event.
+
+        :param distance: how far to zoom in.
+        """
+        self.orbit_dist += self.orbit_dist * distance * self.move_speed
+        self._update_direction_position()
+
+    def move(self, direction: MoveDir, distance: float = 1.0):
+        """
+        Updates the camera position with a movement event.
+
+        :param direction: the direction to move in.
+        :param distance: the distance to move.
+        """
+        if direction == MoveDir.UP:
+            self.target_pos[1] += self.move_speed * distance
+        elif direction == MoveDir.DOWN:
+            self.target_pos[1] -= self.move_speed * distance
+        elif direction == MoveDir.RIGHT:
+            self.target_pos[0] += self.move_speed * distance
+        elif direction == MoveDir.LEFT:
+            self.target_pos[0] -= self.move_speed * distance
+        elif direction == MoveDir.FORWARD:
+            self.target_pos[2] += self.move_speed * distance
+        elif direction == MoveDir.BACKWARD:
+            self.target_pos[2] -= self.move_speed * distance
+        # log(f"Moved position: {self.position}", severity=logging.INFO)
+

--- a/pySSV/ssv_render.py
+++ b/pySSV/ssv_render.py
@@ -68,6 +68,20 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
+    def get_context_info(self) -> dict[str, str]:
+        """
+        Returns the OpenGL context information.
+        """
+        ...
+
+    @abstractmethod
+    def get_supported_extensions(self) -> set[str]:
+        """
+        Gets the set of supported OpenGL shader compiler extensions.
+        """
+        ...
+
+    @abstractmethod
     def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: (int, int), uniform_name: str,
                             components: int = 4, dtype: str = "f1"):
         """
@@ -148,7 +162,8 @@ class SSVRender(ABC):
     @abstractmethod
     def update_texture(self, texture_uid: int, data: npt.NDArray, uniform_name: Optional[str],
                        override_dtype: Optional[str],
-                       rect: Optional[Union[tuple[int, int, int, int], tuple[int, int, int, int, int, int]]]):
+                       rect: Optional[Union[tuple[int, int, int, int], tuple[int, int, int, int, int, int]]],
+                       treat_as_normalized_integer: bool):
         """
         Creates or updates a texture from the NumPy array provided.
 
@@ -158,6 +173,10 @@ class SSVRender(ABC):
         :param override_dtype: optionally, a moderngl override
         :param rect: optionally, a rectangle (left, top, right, bottom) specifying the area of the target texture to
                      update.
+        :param treat_as_normalized_integer: when enabled, integer types (singed/unsigned) are treated as normalized
+                                            integers by OpenGL, such that when the texture is sampled values in the
+                                            texture are mapped to floats in the range [0, 1] or [-1, 1]. See:
+                                            https://www.khronos.org/opengl/wiki/Normalized_Integer for more details.
         """
         ...
 

--- a/pySSV/ssv_render_process_server.py
+++ b/pySSV/ssv_render_process_server.py
@@ -134,6 +134,10 @@ class SSVRenderProcessServer:
                         self.__shutdown("requested by client")
                         return
 
+    def __send_async_result(self, query_id, *args):
+        # Send an async result back to the client with the client's request id
+        self._command_queue_tx.put(("ARes", query_id, *args))
+
     def __parse_render_command(self, timeout):
         try:
             command, *command_args = self._command_queue_rx.get(block=True, timeout=timeout)
@@ -194,6 +198,14 @@ class SSVRenderProcessServer:
         elif command == "LogT":
             # Log frame times
             self.log_frame_timing = command_args[0]
+        elif command == "GtCt":
+            # Get context info
+            ctx = self._renderer.get_context_info()
+            self.__send_async_result(command_args[0], ctx)
+        elif command == "GtEx":
+            # Get supported extensions
+            ext = self._renderer.get_supported_extensions()
+            self.__send_async_result(command_args[0], ext)
         elif command == "DbRT":
             # Debug Render Test
             pass

--- a/pySSV/ssv_render_widget.py
+++ b/pySSV/ssv_render_widget.py
@@ -14,6 +14,7 @@ from ._frontend import module_name, module_version
 OnMessageDelegate = NewType("OnMessageDelegate", Callable[[], None])
 OnClickDelegate = NewType("OnClickDelegate", Callable[[bool], None])
 OnKeyDelegate = NewType("OnKeyDelegate", Callable[[str, bool], None])
+OnWheelDelegate = NewType("OnWheelDelegate", Callable[[float], None])
 
 
 class SSVRenderWidget(DOMWidget):
@@ -43,6 +44,7 @@ class SSVRenderWidget(DOMWidget):
         self._stop_handlers = CallbackDispatcher()
         self._click_handlers = CallbackDispatcher()
         self._key_handlers = CallbackDispatcher()
+        self._wheel_handlers = CallbackDispatcher()
         self._renderdoc_capture_handlers = CallbackDispatcher()
         self.on_msg(self._handle_widget_msg)
         self._view_count = 0
@@ -62,6 +64,8 @@ class SSVRenderWidget(DOMWidget):
             self._key_handlers(content["keydown"], True)
         elif "keyup" in content:
             self._key_handlers(content["keyup"], False)
+        elif "wheel" in content:
+            self._wheel_handlers(content["wheel"])
         elif "renderdoc_capture" in content:
             self._renderdoc_capture_handlers()
 
@@ -109,6 +113,15 @@ class SSVRenderWidget(DOMWidget):
         :param remove: set to true to remove the callback from the list of callbacks.
         """
         self._key_handlers.register_callback(callback, remove=remove)
+
+    def on_mouse_wheel(self, callback: OnWheelDelegate, remove=False):
+        """
+        Register a callback to execute when the widget receives a mouse wheel event.
+
+        :param callback: the function to be called when the event is raised.
+        :param remove: set to true to remove the callback from the list of callbacks.
+        """
+        self._wheel_handlers.register_callback(callback, remove=remove)
 
     def on_renderdoc_capture(self, callback: OnMessageDelegate, remove=False):
         """

--- a/pySSV/tests/test_ssv_preprocessor.py
+++ b/pySSV/tests/test_ssv_preprocessor.py
@@ -19,7 +19,7 @@ def test_ssv_argparse():
 
 
 def test_ssv_preprocessor():
-    preproc = SSVShaderPreprocessor(gl_version="420")
+    preproc = SSVShaderPreprocessor(gl_version="420", supports_line_directives=True)
     proc_shaders = preproc.preprocess(test_shader, "test_shader.glsl", additional_templates=[test_template])
     assert len(proc_shaders) == 2
     assert "vertex_shader" in proc_shaders

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -69,6 +69,10 @@ export class SSVRenderView extends DOMWidgetView {
 
   render() {
     // Render HTML
+    this.el.classList.add("ssv-colors");
+    if(getComputedStyle(document.documentElement).getPropertyValue("--colab-primary-surface-color").length > 0)
+      this.el.classList.add("ssv-colab-support");
+
     this.el.classList.add("ssv-render-widget");
 
     switch (this.model.get("streaming_mode")) {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -61,6 +61,7 @@ export class SSVRenderView extends DOMWidgetView {
   private _status_resolution_element: HTMLSpanElement | null = null;
   private _log_button_element: HTMLButtonElement | null = null;
   private _log_element: HTMLElement | null = null;
+  private _focussed: boolean = false;
 
   initialize(parameters: WidgetView.IInitializeParameters) {
     super.initialize(parameters);
@@ -98,51 +99,106 @@ export class SSVRenderView extends DOMWidgetView {
       }, 250);
 
       //let mousePos = { x: 0, y: 0 };
-      this._stream_img_element.addEventListener(
-        "mousemove",
-        (event: MouseEvent) => {
-          /*mousePos = {
-            x: event.clientX,// / target.width,
-            y: event.clientY,// / target.height
-          };*/
-
-          if (event?.target == null || !(event.target instanceof HTMLElement))
-            return;
-
-          const rect = event.target.getBoundingClientRect();
-          this.model.set("mouse_pos_x", Math.round(event.clientX - rect.left));
-          this.model.set("mouse_pos_y", Math.round(rect.height - (event.clientY - rect.top)));
-          this.model.save_changes();
-        }
-      );
-      this._stream_img_element.addEventListener(
-        "mousedown",
-        (event: MouseEvent) => {
-          this.send({"mousedown": 0});
-        }
-      );
-      this._stream_img_element.addEventListener(
-        "mouseup",
-        (event: MouseEvent) => {
-          this.send({"mouseup": 0});
-        }
-      );
-      this._stream_img_element.addEventListener(
-        "keydown",
-        (event: KeyboardEvent) => {
-          this.send({"keydown": event.key});
-        }
-      );
-      this._stream_img_element.addEventListener(
-        "keyup",
-        (event: KeyboardEvent) => {
-          this.send({"keyup": event.key});
-        }
-      );
+      this.register_events();
     }
   }
 
-  // Triggered ~250ms to update UI elements which don't need updating frequently
+  remove() {
+    super.remove();
+
+    this.unregister_events();
+  }
+
+  private register_events() {
+    if (this._stream_img_element == null)
+      return;
+    this._stream_img_element.addEventListener(
+      "mousemove",
+      (event: MouseEvent) => {
+        /*mousePos = {
+          x: event.clientX,// / target.width,
+          y: event.clientY,// / target.height
+        };*/
+
+        if (event?.target == null || !(event.target instanceof HTMLElement))
+          return;
+
+        const rect = event.target.getBoundingClientRect();
+        this.model.set("mouse_pos_x", Math.round(event.clientX - rect.left));
+        this.model.set("mouse_pos_y", Math.round(rect.height - (event.clientY - rect.top)));
+        this.model.save_changes();
+      }
+    );
+    this._stream_img_element.addEventListener(
+      "mousedown",
+      (event: MouseEvent) => {
+        this.send({"mousedown": 0});
+      }
+    );
+    this._stream_img_element.addEventListener(
+      "mouseup",
+      (event: MouseEvent) => {
+        this.send({"mouseup": 0});
+      }
+    );
+    this._stream_img_element.addEventListener(
+      "mouseover",
+      (event: MouseEvent) => {
+        this._focussed = true;
+      }
+    );
+    this._stream_img_element.addEventListener(
+      "mouseleave",
+      (event: MouseEvent) => {
+        this._focussed = false;
+      }
+    );
+    window.addEventListener("keypress", this.on_keypress);
+    window.addEventListener("keydown", this.on_keydown);
+    window.addEventListener("keyup", this.on_keyup);
+    window.addEventListener("wheel", this.on_wheel, {passive: false});
+  }
+
+  private on_keypress = (event: KeyboardEvent) => {
+    if (this._focussed) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  private on_keydown = (event: KeyboardEvent) => {
+    if (this._focussed) {
+      this.send({"keydown": event.key});
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  private on_keyup = (event: KeyboardEvent) => {
+    if (this._focussed) {
+      this.send({"keyup": event.key});
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
+
+  private on_wheel = (event: WheelEvent) => {
+    if (this._focussed) {
+      this.send({"wheel": event.deltaY});
+      event.preventDefault();
+    }
+  }
+
+  private unregister_events() {
+    // It's probably a good idea to unregister any events on the document itself. The events on the element, should be
+    // destroyed with the element.
+    window.removeEventListener("keypress", this.on_keypress);
+    window.removeEventListener("keydown", this.on_keydown);
+    window.removeEventListener("keyup", this.on_keyup);
+    window.removeEventListener("wheel", this.on_wheel);
+  }
+
+// Triggered ~250ms to update UI elements which don't need updating frequently
   private slow_update() {
     if (this._status_frame_stats_element) {
       // TODO: FPS counter


### PR DESCRIPTION
 - Updated built-in-shader-templates.rst
 - Support for GL_ARB_shading_language_include is now automatically detected and the extension can now be forced on/off when creating the canvas. Fixes #28
 - Incremented version number
 - SSVCamera is now split into separate Look camera and Orbit camera classes based on the desired interaction behaviour
 - Fixed various camera bugs
 - Added mousewheel support
 - Textures from int/uint arrays now have the option to be treated as normalized integers when being created
 - dbg_preprocess_shader now has the option to pretty print its result
 - Fixed some bugs with textures
 - The renderer IPC layer now supports commands which return results asynchronously.
 - Added get_context_info() and get_supported_extensions() to the renderer
 - Fixed some preprocessor bugs
 - When a template argument is set to its default value the preprocessor now defines an extra macro in the form 'T_<ARGUMENT>_ISDEFAULT'
 - Added custom geometry shader template
 - Updated shader templates to use explicit vertex attribute locations to prevent compiler stripping
 - The point cloud shader template now supports non-square points
 - Added additional_examples.ipnb
 - Improved styling in Google Colab