### PR TITLE
Python 3.8 Compatibility:

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,12 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+      run: |
+        python -m pip install -U "jupyterlab>=4.0.0,<5"
+        python -m pip install -U "mypy"
+
+    - name: Static type checking
+      run: python -m mypy pySSV
 
     # Ignore style issues for now, it's just not worth the trouble at the moment...
     # - name: Lint the extension

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       run: |
         python -m pip install -U "jupyterlab>=4.0.0,<5"
         python -m pip install -U "mypy"
+        set -eux
+        python -m pip install ".[test, docs]"
 
     - name: Static type checking
       run: python -m mypy pySSV

--- a/css/widget.css
+++ b/css/widget.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Thomas Mathieson.
+ * Copyright (c) 2023-2024 Thomas Mathieson.
  * Distributed under the terms of the MIT license.
  */
 
@@ -17,6 +17,7 @@
   --ssv-warn-color1: var(--jp-warn-color1);
 }
 
+/*noinspection CssUnresolvedCustomProperty*/
 .ssv-colab-support.ssv-colors {
   /* We need to change some of the colours here since google colab doesn't seem to support all the jupyter colours. */
   --ssv-bg-color1: var(--colab-primary-surface-color);

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+#  Copyright (c) 2024 Thomas Mathieson.
+#  Distributed under the terms of the MIT license.
+
+# mypy: ignore-errors
+
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 

--- a/examples/additional_examples.ipynb
+++ b/examples/additional_examples.ipynb
@@ -408,7 +408,7 @@
    "outputs": [],
    "source": [
     "# VP9 has improved compression efficiency but is much slower at encoding\n",
-    "make_canvas().run(stream_mode=\"vp9\", stream_quality=10)"
+    "make_canvas().run(stream_mode=\"vp9\", stream_quality=100)"
    ]
   },
   {
@@ -458,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/examples/gui_examples.ipynb
+++ b/examples/gui_examples.ipynb
@@ -143,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/examples/introduction.ipynb
+++ b/examples/introduction.ipynb
@@ -802,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.8.18"
   }
  },
  "nbformat": 4,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+# mypy type checker config
+[mypy]
+python_version=3.8
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "py-ssv",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Leverage the power of shaders for scientific visualisation in Jupyter",
     "keywords": [
         "jupyter",

--- a/pySSV/__init__.py
+++ b/pySSV/__init__.py
@@ -7,7 +7,7 @@ from .ssv_canvas import SSVCanvas
 from .ssv_logging import log
 
 try:
-    from ._version import __version__
+    from ._version import __version__  # type: ignore
 except ImportError:
     # Fallback when using the package in dev mode without installing in editable mode with pip. It is highly
     # recommended to install the package from a stable release or in editable mode:

--- a/pySSV/__init__.py
+++ b/pySSV/__init__.py
@@ -1,6 +1,6 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
-from typing import Optional
+from typing import Optional, Tuple
 
 from .ssv_render_widget import SSVRenderWidget
 from .ssv_canvas import SSVCanvas
@@ -35,7 +35,7 @@ def _jupyter_nbextension_paths():
 
 # Various factory methods
 
-def canvas(size: Optional[tuple[int, int]] = (640, 480), backend: str = "opengl", standalone: bool = False,
+def canvas(size: Optional[Tuple[int, int]] = (640, 480), backend: str = "opengl", standalone: bool = False,
            target_framerate: int = 60, use_renderdoc: bool = False, supports_line_directives: Optional[bool] = None):
     """
     Creates a new ``SSVCanvas`` which contains the render widget and manages the render context.

--- a/pySSV/_frontend.py
+++ b/pySSV/_frontend.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 
 
@@ -10,7 +10,7 @@ Information about the frontend package of the widgets.
 """
 
 try:
-    from ._version import __version__
+    from ._version import __version__  # type: ignore
 except ImportError:
     __version__ = "dev"
 

--- a/pySSV/environment.py
+++ b/pySSV/environment.py
@@ -1,11 +1,10 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 
 # This snippet for detecting the python environment is taken from:
 # https://github.com/InsightSoftwareConsortium/itkwidgets/blob/main/itkwidgets/integrations/environment.py Licensed
 # under the Apache License 2.0: https://github.com/InsightSoftwareConsortium/itkwidgets/blob/main/LICENSE
 from enum import Enum
-from importlib import import_module
 import sys
 
 
@@ -20,11 +19,14 @@ class Env(Enum):
 
 def find_env():
     try:
-        from google.colab import files
+        from google.colab import files  # type: ignore
         return Env.COLAB
-    except:
+    except ImportError:
         try:
-            from IPython import get_ipython
+            from IPython import get_ipython  # type: ignore
+            if get_ipython() is None:
+                # Hack
+                return Env.JUPYTERLAB
             parent_header = get_ipython().parent_header
             username = parent_header['header']['username']
             if username == '':
@@ -33,7 +35,7 @@ def find_env():
                 return Env.JUPYTER_NOTEBOOK
             else:
                 return Env.SAGEMAKER
-        except:
+        except ImportError:
             import sys
             if sys.platform == 'emscripten':
                 return Env.JUPYTERLITE

--- a/pySSV/ssv_callback_dispatcher.py
+++ b/pySSV/ssv_callback_dispatcher.py
@@ -1,6 +1,6 @@
 #  Copyright (c) 2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, TypeVar, Set
 
 
 T = TypeVar("T", bound=Callable[..., None])
@@ -10,7 +10,7 @@ class SSVCallbackDispatcher(Generic[T]):
     """
     A simple event callback dispatcher class similar to the ``ipywidgets.widgets.widget.CallbackDispatcher``.
     """
-    _callbacks: set[T]
+    _callbacks: Set[T]
 
     def __init__(self):
         self._callbacks = set()

--- a/pySSV/ssv_camera.py
+++ b/pySSV/ssv_camera.py
@@ -283,7 +283,7 @@ class SSVOrbitCameraController(SSVCameraController):
         :param direction: the direction to move in.
         :param distance: the distance to move.
         """
-        dir_vec = np.zeros(4, dtype=np.float32)
+        dir_vec: npt.NDArray[np.float32] = np.zeros(4, dtype=np.float32)
         if direction == MoveDir.UP:
             dir_vec[1] = self.move_speed * distance
         elif direction == MoveDir.DOWN:

--- a/pySSV/ssv_canvas.py
+++ b/pySSV/ssv_canvas.py
@@ -1,16 +1,16 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 import logging
 import time
-from typing import Optional, Any, Union, Callable, NewType, Type
+from typing import Optional, Any, Union, Callable, Dict, List, Tuple
 from threading import Thread
 import numpy.typing as npt
-try:
-    from PIL import Image
-    _PIL_SUPPORTED = True
-except ImportError:
-    Image = None
-    _PIL_SUPPORTED = False
+from PIL import Image
+import sys
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
 
 from .ssv_camera import SSVCameraController, SSVOrbitCameraController, SSVLookCameraController, MoveDir
 from .ssv_render_process_client import SSVRenderProcessClient
@@ -25,7 +25,7 @@ from .ssv_canvas_stream_server import SSVCanvasStreamServer
 from .environment import ENVIRONMENT, Env
 
 
-OnMouseDelegate = NewType("OnMouseDelegate", Callable[[tuple[bool, bool, bool], tuple[int, int], float], None])
+OnMouseDelegate: TypeAlias = Callable[[Tuple[bool, bool, bool], Tuple[int, int], float], None]
 """
 A callable with parameters matching the signature::
 
@@ -36,7 +36,7 @@ A callable with parameters matching the signature::
 | mouse_pos: a tuple of ints representing the mouse position relative to the canvas in pixels.
 | mouse_wheel_delta: how many pixels the mousewheel has scrolled since the last callback.
 """
-OnKeyDelegate = NewType("OnKeyDelegate", Callable[[str, bool], None])
+OnKeyDelegate: TypeAlias = Callable[[str, bool], None]
 """
 A callable with parameters matching the signature::
 
@@ -47,6 +47,15 @@ A callable with parameters matching the signature::
        https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
 | down: whether the key is being pressed.
 """
+OnFrameRenderedDelegate: TypeAlias = Callable[[float], None]
+"""
+A callable with parameters matching the signature::
+
+    on_key(delta_time: float) -> None:
+        ...
+
+| key: the time in seconds since the last frame was rendered.
+"""
 
 
 class SSVCanvas:
@@ -54,7 +63,7 @@ class SSVCanvas:
     An SSV canvas manages the OpenGL rendering context, shaders, and the jupyter widget
     """
 
-    def __init__(self, size: Optional[tuple[int, int]], backend: str = "opengl", standalone: bool = False,
+    def __init__(self, size: Optional[Tuple[int, int]], backend: str = "opengl", standalone: bool = False,
                  target_framerate: int = 60, use_renderdoc: bool = False,
                  supports_line_directives: Optional[bool] = None):
         """
@@ -82,11 +91,11 @@ class SSVCanvas:
         self._use_renderdoc = False
         self._on_mouse_event: SSVCallbackDispatcher[OnMouseDelegate] = SSVCallbackDispatcher()
         self._on_keyboard_event: SSVCallbackDispatcher[OnKeyDelegate] = SSVCallbackDispatcher()
-        self._on_frame_rendered: SSVCallbackDispatcher[Callable[[], None]] = SSVCallbackDispatcher()
+        self._on_frame_rendered: SSVCallbackDispatcher[OnFrameRenderedDelegate] = SSVCallbackDispatcher()
         self._on_start: SSVCallbackDispatcher[Callable[[], None]] = SSVCallbackDispatcher()
         if use_renderdoc:
             try:
-                from pyRenderdocApp import RENDERDOC_API_1_6_0
+                from pyRenderdocApp import RENDERDOC_API_1_6_0  # type: ignore
                 self._use_renderdoc = True
             except ImportError:
                 log("Couldn't find pyRenderdocApp module! Renderdoc will not be loaded.", severity=logging.WARN)
@@ -111,7 +120,10 @@ class SSVCanvas:
                                                              self._use_renderdoc)
         if supports_line_directives is None:
             supported_extensions = self._render_process_client.get_supported_extensions()
-            supports_line_directives = "GL_ARB_shading_language_include" in supported_extensions
+            if supported_extensions is not None:
+                supports_line_directives = "GL_ARB_shading_language_include" in supported_extensions
+            else:
+                supports_line_directives = False
         self._preprocessor = SSVShaderPreprocessor(gl_version="420", supports_line_directives=supports_line_directives)
 
         self._supports_websockets = ENVIRONMENT != Env.COLAB or ENVIRONMENT != Env.JUPYTERLITE
@@ -121,7 +133,7 @@ class SSVCanvas:
         self._mouse_pos = (0, 0)
         self._mouse_down = (False, False, False)
         # Cache the last parameters to the run() method for the widget's "play" button to use
-        self._last_run_settings = {}
+        self._last_run_settings: Dict[str, Any] = {}
         self._paused = False
 
         # Set up a default render buffer
@@ -131,7 +143,9 @@ class SSVCanvas:
         self._render_buffer_counter = 1
         self._main_camera = SSVOrbitCameraController()
         self._main_camera.aspect_ratio = size[1] / size[0]
-        self._textures: dict[str, SSVTexture] = {}
+        self._current_move_dir: MoveDir = MoveDir.NONE
+        self._last_frame_time = time.perf_counter()
+        self._textures: Dict[str, SSVTexture] = {}
 
     def __del__(self):
         self.stop()
@@ -159,19 +173,29 @@ class SSVCanvas:
     def __on_render(self, stream_data: Union[bytes, str]):
         if self._streaming_mode == SSVStreamingMode.MJPEG and self._canvas_stream_server is not None:
             # log(f"Sending frame len={len(stream_data)}", severity=logging.INFO)
-            self._canvas_stream_server.send(stream_data)
+            self._canvas_stream_server.send(stream_data)  # type: ignore
         elif self._supports_websockets and self._canvas_stream_server is not None:
             # log(f"Sending frame len={len(stream_data)}", severity=logging.INFO)
             if isinstance(stream_data, str):
                 stream_data = stream_data.encode('utf-8')
             self._canvas_stream_server.send(stream_data)
-        else:
+        elif self._widget is not None:
             if isinstance(stream_data, str):
                 self._widget.stream_data_ascii = stream_data
             else:
                 self._widget.stream_data_binary = stream_data
             # log(f"Sending frame len={len(stream_data)}", severity=logging.INFO)
             # self._widget.send({"stream_data": len(stream_data)}, buffers=[stream_data])
+        t = time.perf_counter()
+        delta_time = t - self._last_frame_time
+        self._last_frame_time = t
+        # Update camera
+        if self._current_move_dir != MoveDir.NONE:
+            self._main_camera.move(self._current_move_dir, delta_time)
+            self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                       self._main_camera.view_matrix)
+        # Invoke callbacks
+        self._on_frame_rendered(delta_time)
 
     def __on_heartbeat(self):
         self._render_process_client.send_heartbeat()
@@ -183,7 +207,7 @@ class SSVCanvas:
         # self.run(**self._last_run_settings)
         self._paused = False
         if "stream_quality" in self._last_run_settings:
-            self._render_process_client.render(self._target_framerate, str(self._streaming_mode),
+            self._render_process_client.render(self._target_framerate, self._streaming_mode.value,
                                                self._last_run_settings["stream_quality"])
 
     def __on_stop(self):
@@ -197,22 +221,25 @@ class SSVCanvas:
                             self._mouse_down[2] if button != 2 else down)
         self._render_process_client.update_uniform(None, None, "uMouseDown", down)
         self._main_camera.mouse_change(self._mouse_pos, self._mouse_down)
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
+        self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                   self._main_camera.view_matrix)
         self._on_mouse_event(self._mouse_down, self._mouse_pos, 0)
+
+    def __update_camera_pos(self, key: str, down: bool):
+        if key == "ArrowUp" or key == "w" or key == "W" or key == "z" or key == "Z":
+            self._current_move_dir = MoveDir.FORWARD if down else MoveDir.NONE
+        elif key == "ArrowDown" or key == "s" or key == "S":
+            self._current_move_dir = MoveDir.BACKWARD if down else MoveDir.NONE
+        elif key == "ArrowLeft" or key == "a" or key == "A" or key == "q" or key == "Q":
+            self._current_move_dir = MoveDir.LEFT if down else MoveDir.NONE
+        elif key == "ArrowRight" or key == "d" or key == "D":
+            self._current_move_dir = MoveDir.RIGHT if down else MoveDir.NONE
 
     def __on_key(self, key: str, down: bool):
         if self._paused:
             return
         # TODO: Shader uniform/texture for keyboard support
-        if key == "ArrowUp" or key == "w" or key == "W" or key == "z" or key == "Z":
-            self._main_camera.move(MoveDir.FORWARD)
-        elif key == "ArrowDown" or key == "s" or key == "S":
-            self._main_camera.move(MoveDir.BACKWARD)
-        elif key == "ArrowLeft" or key == "a" or key == "A" or key == "q" or key == "Q":
-            self._main_camera.move(MoveDir.LEFT)
-        elif key == "ArrowRight" or key == "d" or key == "D":
-            self._main_camera.move(MoveDir.RIGHT)
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
+        self.__update_camera_pos(key, down)
         self._on_keyboard_event(key, down)
 
     def __on_renderdoc_capture(self):
@@ -223,25 +250,30 @@ class SSVCanvas:
         if self._paused:
             return
         self._main_camera.zoom(value * 0.05)
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
+        self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                   self._main_camera.view_matrix)
         self._on_mouse_event(self._mouse_down, self._mouse_pos, value)
 
     def __on_mouse_x_updated(self, x):
         if self._paused:
             return
         self._mouse_pos = (x.new, self._mouse_pos[1])
-        self._render_process_client.update_uniform(None, None, "uMouse", tuple(self._mouse_pos))
+        self._render_process_client.update_uniform(None, None, "uMouse",
+                                                   tuple(self._mouse_pos))
         self._main_camera.mouse_change(self._mouse_pos, self._mouse_down)
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
+        self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                   self._main_camera.view_matrix)
         self._on_mouse_event(self._mouse_down, self._mouse_pos, 0)
 
     def __on_mouse_y_updated(self, y):
         if self._paused:
             return
         self._mouse_pos = (self._mouse_pos[0], y.new)
-        self._render_process_client.update_uniform(None, None, "uMouse", tuple(self._mouse_pos))
+        self._render_process_client.update_uniform(None, None, "uMouse",
+                                                   tuple(self._mouse_pos))
         self._main_camera.mouse_change(self._mouse_pos, self._mouse_down)
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
+        self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                   self._main_camera.view_matrix)
         self._on_mouse_event(self._mouse_down, self._mouse_pos, 0)
 
     @property
@@ -254,7 +286,7 @@ class SSVCanvas:
         return self._main_render_buffer
 
     @property
-    def size(self) -> tuple[int, int]:
+    def size(self) -> Tuple[int, int]:
         """Gets the size of the canvas in pixels"""
         return self._size
 
@@ -274,12 +306,12 @@ class SSVCanvas:
         return self._main_camera
 
     @property
-    def mouse_down(self) -> tuple[bool, bool, bool]:
+    def mouse_down(self) -> Tuple[bool, bool, bool]:
         """Gets the current mouse button state as a tuple of ``bool``. [left, right, middle]"""
         return self._mouse_down
 
     @property
-    def mouse_pos(self) -> tuple[int, int]:
+    def mouse_pos(self) -> Tuple[int, int]:
         """Gets the current mouse position relative to the canvas in pixels."""
         return self._mouse_pos
 
@@ -318,7 +350,7 @@ class SSVCanvas:
         """
         self._on_keyboard_event.register_callback(callback, remove)
 
-    def on_frame_rendered(self, callback: Callable[[], None], remove: bool = False):
+    def on_frame_rendered(self, callback: OnFrameRenderedDelegate, remove: bool = False):
         """
         Registers/unregisters a callback which is invoked when.
 
@@ -362,7 +394,7 @@ class SSVCanvas:
         self._render_process_client.subscribe_on_render(self.__on_render)
         self._on_start()
 
-        if not self._standalone:
+        if self._widget is not None:
             from IPython.display import display
             self._widget.streaming_mode = self._streaming_mode.name
             self._widget.use_websockets = self._supports_websockets
@@ -384,8 +416,10 @@ class SSVCanvas:
                 self._update_frame_rate_task.start()
 
         # Make sure the view and projection matrices are defined before rendering
-        self._render_process_client.update_uniform(None, None, "uViewMat", self._main_camera.view_matrix)
-        self._render_process_client.update_uniform(None, None, "uProjMat", self._main_camera.projection_matrix)
+        self._render_process_client.update_uniform(None, None, "uViewMat",
+                                                   self._main_camera.view_matrix)
+        self._render_process_client.update_uniform(None, None, "uProjMat",
+                                                   self._main_camera.projection_matrix)
 
         self._render_process_client.set_timeout(None if never_kill else self._render_timeout)
         self._render_process_client.render(self._target_framerate, self._streaming_mode.value, stream_quality)
@@ -401,12 +435,12 @@ class SSVCanvas:
         if force:
             self._render_process_client.stop()
         else:
-            self._render_process_client.render(0, str(self._streaming_mode))
+            self._render_process_client.render(0, self._streaming_mode.value)
 
     def shader(self, shader_source: str, additional_template_directory: Optional[str] = None,
-               additional_templates: Optional[list[str]] = None,
-               shader_defines: Optional[dict[str, str]] = None,
-               compiler_extensions: Optional[list[str]] = None):
+               additional_templates: Optional[List[str]] = None,
+               shader_defines: Optional[Dict[str, str]] = None,
+               compiler_extensions: Optional[List[str]] = None):
         """
         Registers, compiles and attaches a shader to the main render buffer.
 
@@ -438,7 +472,7 @@ class SSVCanvas:
         """
         self._main_render_buffer.update_uniform(uniform_name, value, share_with_render_buffer, share_with_canvas)
 
-    def render_buffer(self, size: tuple[int, int], name: Optional[str] = None, order: int = 0, dtype: str = "f1",
+    def render_buffer(self, size: Tuple[int, int], name: Optional[str] = None, order: int = 0, dtype: str = "f1",
                       components: int = 4) -> SSVRenderBuffer:
         """
         Creates a new render buffer for this canvas. Useful for effects requiring multi pass rendering.
@@ -448,7 +482,8 @@ class SSVCanvas:
                      declaration. If set to ``None`` a name is automatically generated.
         :param order: a number to hint the renderer as to the order to render the buffers in. Smaller values are
                       rendered first; the main render buffer has an order of 999999.
-        :param dtype: the data type for each pixel component (see: https://moderngl.readthedocs.io/en/5.8.2/topics/texture_formats.html).
+        :param dtype: the data type for each pixel component (see:
+                      https://moderngl.readthedocs.io/en/5.8.2/topics/texture_formats.html).
         :param components: how many vector components should each pixel have (RGB=3, RGBA=4).
         :return: a new render buffer object.
         """
@@ -457,8 +492,8 @@ class SSVCanvas:
         return SSVRenderBuffer(self, self._render_process_client, self._preprocessor, None,
                                render_buffer_name, order, size, dtype, components)
 
-    def texture(self, data: Union[npt.NDArray, Image], uniform_name: Optional[str], force_2d: bool = False, force_3d: bool = False,
-                override_dtype: Optional[str] = None, treat_as_normalized_integer: bool = True,
+    def texture(self, data: Union[npt.NDArray, Image.Image], uniform_name: Optional[str], force_2d: bool = False,
+                force_3d: bool = False, override_dtype: Optional[str] = None, treat_as_normalized_integer: bool = True,
                 declare_uniform: bool = True) -> SSVTexture:
         """
         Creates or updates a texture from the NumPy array provided.
@@ -530,10 +565,10 @@ class SSVCanvas:
         return f"Found shader templates: \n\n{shaders}"
 
     def dbg_preprocess_shader(self, shader_source: str, additional_template_directory: Optional[str] = None,
-                              additional_templates: Optional[list[str]] = None,
-                              shader_defines: Optional[dict[str, str]] = None,
-                              compiler_extensions: Optional[list[str]] = None,
-                              pretty_print: bool = True) -> Union[str, dict[str, str]]:
+                              additional_templates: Optional[List[str]] = None,
+                              shader_defines: Optional[Dict[str, str]] = None,
+                              compiler_extensions: Optional[List[str]] = None,
+                              pretty_print: bool = True) -> Union[str, Dict[str, str]]:
         """
         Runs the preprocessor on a shader and returns the results. Useful for debugging shaders.
 
@@ -564,16 +599,16 @@ class SSVCanvas:
         if "primitive_type" in shaders and shaders["primitive_type"] is None:
             del shaders["primitive_type"]
 
-        stages = shaders.keys()
-        shaders = shaders.values()
+        stages = list(shaders.keys())
+        shaders_vals = list(shaders.values())
         stages = [f"////////////////////////////////////////\n"
                   f"// {stage.upper():^34} //\n"
                   f"////////////////////////////////////////\n\n" for stage in stages]
-        shaders = [f"{shader}\n\n\n" for shader in shaders]
+        shaders_vals = [f"{shader}\n\n\n" for shader in shaders_vals]
         preproc_src = f"/************************************************************\n" \
                       f" * {f'pySSV Shader Preprocessor version: {VERSION}':^56} *\n" \
                       f" ************************************************************/\n\n"
-        preproc_src += "".join([str(s) for shader in zip(stages, shaders) for s in shader])
+        preproc_src += "".join([str(s) for shader in zip(stages, shaders_vals) for s in shader])
 
         return preproc_src
 

--- a/pySSV/ssv_canvas.py
+++ b/pySSV/ssv_canvas.py
@@ -592,7 +592,10 @@ class SSVCanvas:
         if not pretty_print:
             return shaders
 
-        from ._version import VERSION
+        try:
+            from ._version import __version__  # type: ignore
+        except ImportError:
+            __version__ = "dev"
 
         # Primitive type is always defined but often set to None (so that it defaults to triangles); in this case it
         # isn't relevant to show, so we strip it.
@@ -606,7 +609,7 @@ class SSVCanvas:
                   f"////////////////////////////////////////\n\n" for stage in stages]
         shaders_vals = [f"{shader}\n\n\n" for shader in shaders_vals]
         preproc_src = f"/************************************************************\n" \
-                      f" * {f'pySSV Shader Preprocessor version: {VERSION}':^56} *\n" \
+                      f" * {f'pySSV Shader Preprocessor version: {__version__}':^56} *\n" \
                       f" ************************************************************/\n\n"
         preproc_src += "".join([str(s) for shader in zip(stages, shaders_vals) for s in shader])
 

--- a/pySSV/ssv_canvas_stream_server.py
+++ b/pySSV/ssv_canvas_stream_server.py
@@ -2,7 +2,7 @@
 #  Distributed under the terms of the MIT license.
 import logging
 import time
-import portpicker
+import portpicker  # type: ignore
 from websockets.sync.server import serve, ServerConnection, WebSocketServer
 from websockets import ConnectionClosed
 from threading import Thread, ThreadError, current_thread
@@ -15,7 +15,7 @@ from .ssv_logging import log
 
 
 class SSVCanvasStreamServerHTTP(BaseHTTPRequestHandler):
-    def __init__(self, msg_queue: SimpleQueue[bytes], is_alive: Callable[[], bool], *args, **kwargs):
+    def __init__(self, msg_queue: SimpleQueue, is_alive: Callable[[], bool], *args, **kwargs):
         self._msg_queue = msg_queue
         self._is_alive = is_alive
         super().__init__(*args, **kwargs)
@@ -78,6 +78,7 @@ class SSVCanvasStreamServer:
     def url(self) -> str:
         """Gets the URL of this websocket."""
         if self._http:
+            # noinspection HttpUrlsUsage
             return f"http://{self._hostname}:{self._port}/"
         else:
             return f"ws://{self._hostname}:{self._port}/"

--- a/pySSV/ssv_colour.py
+++ b/pySSV/ssv_colour.py
@@ -1,5 +1,7 @@
 #  Copyright (c) 2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
+from typing import Tuple
+
 
 class Colour:
     """
@@ -45,7 +47,7 @@ class Colour:
             raise TypeError(f"Can't add Colour to {type(other)}!")
 
     @property
-    def astuple(self) -> tuple[float, float, float, float]:
+    def astuple(self) -> Tuple[float, float, float, float]:
         """Gets the (r, g, b, a) tuple of this colour."""
         return self.r, self.g, self.b, self.a
 

--- a/pySSV/ssv_fonts.py
+++ b/pySSV/ssv_fonts.py
@@ -2,10 +2,15 @@
 #  Distributed under the terms of the MIT license.
 import logging
 import os.path
-from importlib.resources import as_file, files
+import sys
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+else:
+    from importlib.resources import open_binary, read_text
 import xml.etree.ElementTree as et
 from dataclasses import dataclass
 from PIL import Image
+from typing import Optional, Dict
 
 from .ssv_logging import log
 
@@ -22,14 +27,17 @@ def _find_font(font_path: str) -> str:
             return f.read()
 
     try:
-        template_traversable = files("pySSV.fonts").joinpath(font_path)
-        return template_traversable.read_text()
+        if sys.version_info >= (3, 9):
+            template_traversable = files("pySSV.fonts").joinpath(font_path)
+            return template_traversable.read_text()
+        else:
+            return read_text("pySSV.fonts", font_path)
     except Exception as e:
         raise FileNotFoundError(f"Couldn't find/read the font: '{font_path}'. \n"
                                 f"Inner exception: {e}")
 
 
-def _load_bitmap(bitmap_path: str, font_path: str) -> Image:
+def _load_bitmap(bitmap_path: str, font_path: str) -> Image.Image:
     """
     Attempts to load a font bitmap from the file system or from pySSV's built in fonts directory.
 
@@ -47,8 +55,11 @@ def _load_bitmap(bitmap_path: str, font_path: str) -> Image:
             return Image.open(path)
 
     try:
-        template_traversable = files("pySSV.fonts").joinpath(bitmap_path)
-        f = template_traversable.open("rb")
+        if sys.version_info >= (3, 9):
+            template_traversable = files("pySSV.fonts").joinpath(bitmap_path)
+            f = template_traversable.open("rb")
+        else:
+            f = open_binary("pySSV.fonts", bitmap_path)
         return Image.open(f)
     except Exception as e:
         raise FileNotFoundError(f"Couldn't find/read the font bitmap: '{bitmap_path}'. \n"
@@ -94,46 +105,52 @@ class SSVFont:
         try:
             info = bm_font.find("info")
             common = bm_font.find("common")
-            self.font_name = info.get("face")
-            self.is_bold = info.get("bold") == "1"
-            self.is_italic = info.get("italic") == "1"
-            self.size = int(info.get("size"))
-            self.line_height = int(common.get("lineHeight"))
-            self.base_height = int(common.get("base"))
-            self.width = int(common.get("scaleW"))
-            self.height = int(common.get("scaleH"))
-            self.pages = int(common.get("pages"))
+            self.font_name: str = info.get("face")  # type: ignore
+            self.is_bold: bool = info.get("bold") == "1"  # type: ignore
+            self.is_italic: bool = info.get("italic") == "1"  # type: ignore
+            self.size: int = int(info.get("size"))  # type: ignore
+            self.line_height: int = int(common.get("lineHeight"))  # type: ignore
+            self.base_height: int = int(common.get("base"))  # type: ignore
+            self.width: int = int(common.get("scaleW"))  # type: ignore
+            self.height: int = int(common.get("scaleH"))  # type: ignore
+            self.pages: int = int(common.get("pages"))  # type: ignore
             if self.pages != 1:
                 raise ValueError(f"Font {self.font_name} has {self.pages} font pages, currently only 1 page is "
                                  f"supported.")
 
             distance_field = bm_font.find("distanceField")
+            self.sdf_distance: Optional[int] = None
             if distance_field is not None:
-                self.sdf_distance = int(distance_field.get("distanceRange"))
-            else:
-                self.sdf_distance = None
+                self.sdf_distance = int(distance_field.get("distanceRange"))  # type: ignore
 
-            self.bitmap_path = bm_font.find("pages").find("page").get("file")
+            self.bitmap_path: str = bm_font.find("pages").find("page").get("file")  # type: ignore
+            if self.bitmap_path is None:
+                raise ValueError("Font bitmap path is not defined.")
         except Exception as e:
             raise ValueError(f"Error while parsing font file '{font_path}'. \n"
                              f"Inner exception: {e}")
         self.bitmap = _load_bitmap(self.bitmap_path, font_path)
-        self._parse_chars(bm_font.find("chars"))
+        self.chars: Dict[str, SSVCharacterDefinition] = {}
+        chars_el = bm_font.find("chars")
+        if chars_el is not None:
+            self._parse_chars(chars_el)
 
     def _parse_chars(self, chars: et.Element):
-        self.chars = {}
         for char in chars.iter("char"):
-            char_id = int(char.get("id"))
-            char = SSVCharacterDefinition(char_id,
-                                          char.get("char", chr(char_id)),
-                                          int(char.get("x")),
-                                          int(char.get("y")),
-                                          int(char.get("width")),
-                                          int(char.get("height")),
-                                          int(char.get("xoffset")),
-                                          int(char.get("yoffset")),
-                                          int(char.get("xadvance")))
-            self.chars[char.char] = char
+            char_id_str = char.get("id")
+            if char_id_str is None:
+                continue
+            char_id = int(char_id_str)
+            char_def = SSVCharacterDefinition(char_id,
+                                              char.get("char", chr(char_id)),  # type: ignore
+                                              int(char.get("x")),  # type: ignore
+                                              int(char.get("y")),  # type: ignore
+                                              int(char.get("width")),  # type: ignore
+                                              int(char.get("height")),  # type: ignore
+                                              int(char.get("xoffset")),  # type: ignore
+                                              int(char.get("yoffset")),  # type: ignore
+                                              int(char.get("xadvance")))  # type: ignore
+            self.chars[char_def.char] = char_def
 
 
 ssv_font_noto_sans_sb = SSVFont("NotoSans-SemiBold.fnt")

--- a/pySSV/ssv_pragma_parser.py
+++ b/pySSV/ssv_pragma_parser.py
@@ -1,47 +1,47 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
-import logging
-import sys
-from typing import Union
-
-import pcpp
 import argparse
+import sys
+from typing import Optional, List, Dict
+
+import pcpp  # type: ignore
 
 from .ssv_logging import log
 from .ssv_shader_args_tokenizer import SSVShaderArgsTokenizer
 
 
 class SSVTemplatePragmaData(argparse.Namespace):
-    command: str = None
+    command: str
     # Define/Arg
-    name: str = None
-    author: str = None
-    description: str = None
+    name: str
+    author: Optional[str] = None
+    description: Optional[str] = None
     # Stage
-    shader_stage: list[str] = None
+    shader_stage: Optional[List[str]] = None
     # Arg
     # name: str = None
     non_positional: bool = False
-    action: str = None
-    default: str = None
-    choices: list[str] = None
-    const: str = None
+    action: Optional[str] = None
+    default: Optional[str] = None
+    choices: Optional[List[str]] = None
+    const: Optional[str] = None
     # description: list[str] = None
     # input_primitive
-    primitive_type: str = None
+    primitive_type: Optional[str] = None
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
 
 class SSVShaderPragmaData(argparse.Namespace):
-    template: str = None
-    args: list[str] = None
+    template: str
+    args: List[str] = []
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
 
+# noinspection PyShadowingBuiltins
 class SSVTemplatePragmaParser(pcpp.Preprocessor):
     """
     This class is responsible for parsing #pragma definitions in SSV shader templates.
@@ -131,7 +131,7 @@ class SSVTemplatePragmaParser(pcpp.Preprocessor):
 
         return True
 
-    def parse(self, input, source=None, ignore=None) -> dict[str, list[SSVTemplatePragmaData]]:
+    def parse(self, input, source=None, ignore=None) -> Dict[str, List[SSVTemplatePragmaData]]:
         """
         Parses the #pragma directives of a shader template.
 
@@ -156,7 +156,7 @@ class SSVTemplatePragmaParser(pcpp.Preprocessor):
                 for args in self._pragma_args]
 
         # Group arguments into a dictionary
-        args_dict = {}
+        args_dict: Dict[str, List[SSVTemplatePragmaData]] = {}
         for arg in args:
             if arg.command in args_dict:
                 args_dict[arg.command].append(arg)

--- a/pySSV/ssv_render.py
+++ b/pySSV/ssv_render.py
@@ -1,8 +1,8 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional, Any, Union
+from typing import Optional, Any, Union, Tuple, Set, Dict
 
 import numpy.typing as npt
 
@@ -68,21 +68,21 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def get_context_info(self) -> dict[str, str]:
+    def get_context_info(self) -> Dict[str, str]:
         """
         Returns the OpenGL context information.
         """
         ...
 
     @abstractmethod
-    def get_supported_extensions(self) -> set[str]:
+    def get_supported_extensions(self) -> Set[str]:
         """
         Gets the set of supported OpenGL shader compiler extensions.
         """
         ...
 
     @abstractmethod
-    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: (int, int), uniform_name: str,
+    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: Tuple[int, int], uniform_name: str,
                             components: int = 4, dtype: str = "f1"):
         """
         Updates the resolution/format of the given frame buffer. Note that framebuffer 0 is always used for output.
@@ -93,7 +93,8 @@ class SSVRender(ABC):
         :param size: the new resolution of the framebuffer.
         :param uniform_name: the name of the uniform to bind this frame buffer to.
         :param components: how many vector components should each pixel have (RGB=3, RGBA=4).
-        :param dtype: the data type for each pixel component (see: https://moderngl.readthedocs.io/en/5.8.2/topics/texture_formats.html).
+        :param dtype: the data type for each pixel component (see:
+                      https://moderngl.readthedocs.io/en/5.8.2/topics/texture_formats.html).
         """
         ...
 
@@ -124,7 +125,7 @@ class SSVRender(ABC):
     @abstractmethod
     def update_vertex_buffer(self, frame_buffer_uid: int, draw_call_uid: int,
                              vertex_array: Optional[npt.NDArray], index_array: Optional[npt.NDArray],
-                             vertex_attributes: Optional[tuple[str]]):
+                             vertex_attributes: Optional[Tuple[str]]):
         """
         Updates the data inside a vertex buffer.
 
@@ -162,7 +163,7 @@ class SSVRender(ABC):
     @abstractmethod
     def update_texture(self, texture_uid: int, data: npt.NDArray, uniform_name: Optional[str],
                        override_dtype: Optional[str],
-                       rect: Optional[Union[tuple[int, int, int, int], tuple[int, int, int, int, int, int]]],
+                       rect: Optional[Union[Tuple[int, int, int, int], Tuple[int, int, int, int, int, int]]],
                        treat_as_normalized_integer: bool):
         """
         Creates or updates a texture from the NumPy array provided.

--- a/pySSV/ssv_render_buffer.py
+++ b/pySSV/ssv_render_buffer.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Any
@@ -48,7 +48,8 @@ class SSVRenderBuffer:
         self._dtype = dtype
 
         # Register this frame buffer
-        render_process_client.update_frame_buffer(self._render_buffer_uid, order, size, render_buffer_name, components, dtype)
+        render_process_client.update_frame_buffer(self._render_buffer_uid, order, size, render_buffer_name,
+                                                  components, dtype)
         # TODO: Support sampler3D
         preprocessor.add_dynamic_uniform(render_buffer_name, "sampler2D")
 

--- a/pySSV/ssv_render_opengl.py
+++ b/pySSV/ssv_render_opengl.py
@@ -2,7 +2,7 @@
 #  Distributed under the terms of the MIT license.
 import logging
 import time
-from typing import Optional, Any, Union, Tuple, Set, Dict, List
+from typing import Optional, Any, Union, Tuple, Set, Dict, List, cast
 from dataclasses import dataclass
 
 import moderngl
@@ -25,19 +25,19 @@ except ImportError:
     def load_render_doc(renderdoc_path: Optional[str] = None) -> RENDERDOC_API_1_6_0:  # type: ignore[no-redef]
         return RENDERDOC_API_1_6_0()
 
-PRIMITIVE_TYPES = {
-    "POINTS": moderngl.POINTS,
-    "LINES": moderngl.LINES,
-    "LINE_LOOP": moderngl.LINE_LOOP,
-    "LINE_STRIP": moderngl.LINE_STRIP,
-    "TRIANGLES": moderngl.TRIANGLES,
-    "TRIANGLE_STRIP": moderngl.TRIANGLE_STRIP,
-    "TRIANGLE_FAN": moderngl.TRIANGLE_FAN,
-    "LINES_ADJACENCY": moderngl.LINES_ADJACENCY,
-    "LINE_STRIP_ADJACENCY": moderngl.LINE_STRIP_ADJACENCY,
-    "TRIANGLES_ADJACENCY": moderngl.TRIANGLES_ADJACENCY,
-    "TRIANGLE_STRIP_ADJACENCY": moderngl.TRIANGLE_STRIP_ADJACENCY,
-    "PATCHES": moderngl.PATCHES
+PRIMITIVE_TYPES: Dict[str, int] = {
+    "POINTS": cast(int, moderngl.POINTS),
+    "LINES": cast(int, moderngl.LINES),
+    "LINE_LOOP": cast(int, moderngl.LINE_LOOP),
+    "LINE_STRIP": cast(int, moderngl.LINE_STRIP),
+    "TRIANGLES": cast(int, moderngl.TRIANGLES),
+    "TRIANGLE_STRIP": cast(int, moderngl.TRIANGLE_STRIP),
+    "TRIANGLE_FAN": cast(int, moderngl.TRIANGLE_FAN),
+    "LINES_ADJACENCY": cast(int, moderngl.LINES_ADJACENCY),
+    "LINE_STRIP_ADJACENCY": cast(int, moderngl.LINE_STRIP_ADJACENCY),
+    "TRIANGLES_ADJACENCY": cast(int, moderngl.TRIANGLES_ADJACENCY),
+    "TRIANGLE_STRIP_ADJACENCY": cast(int, moderngl.TRIANGLE_STRIP_ADJACENCY),
+    "PATCHES": cast(int, moderngl.PATCHES)
 }
 
 
@@ -357,7 +357,8 @@ class SSVRenderOpenGL(SSVRender):
                                  tess_control_shader=tess_control_shader,
                                  tess_evaluation_shader=tess_evaluation_shader))
 
-            draw_call.primitive_type = moderngl.TRIANGLES if primitive_type is None else PRIMITIVE_TYPES[primitive_type]
+            draw_call.primitive_type = cast(int, moderngl.TRIANGLES if primitive_type is None
+            else PRIMITIVE_TYPES[primitive_type])
 
             # Creating a new shader program invalidates any previously bound vertex arrays, so we need to recreate it.
             # Annoyingly, to support the "default" case where the user doesn't call update_vertex_buffer() we need to
@@ -439,33 +440,37 @@ class SSVRenderOpenGL(SSVRender):
 
         if linear_filtering is not None:
             old_filter = texture.filter
-            if old_filter[0] >= moderngl.NEAREST_MIPMAP_NEAREST:
+            if old_filter[0] >= cast(int, moderngl.NEAREST_MIPMAP_NEAREST):
                 # Texture has mipmaps
                 mipmap = (old_filter[0] == moderngl.LINEAR_MIPMAP_LINEAR
                           or old_filter[0] == moderngl.NEAREST_MIPMAP_LINEAR)
                 if linear_filtering:
-                    texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR if mipmap else moderngl.LINEAR_MIPMAP_NEAREST,
-                                      moderngl.LINEAR)
+                    texture.filter = (cast(int, moderngl.LINEAR_MIPMAP_LINEAR if mipmap
+                                      else moderngl.LINEAR_MIPMAP_NEAREST),
+                                      cast(int, moderngl.LINEAR))
                 else:
-                    texture.filter = (moderngl.NEAREST_MIPMAP_LINEAR if mipmap else moderngl.NEAREST_MIPMAP_NEAREST,
-                                      moderngl.NEAREST)
+                    texture.filter = (cast(int, moderngl.NEAREST_MIPMAP_LINEAR if mipmap
+                                      else moderngl.NEAREST_MIPMAP_NEAREST),
+                                      cast(int, moderngl.NEAREST))
             else:
                 # Texture doesn't use mipmaps
                 if linear_filtering:
-                    texture.filter = (moderngl.LINEAR, moderngl.LINEAR)
+                    texture.filter = (cast(int, moderngl.LINEAR), cast(int, moderngl.LINEAR))
                 else:
-                    texture.filter = (moderngl.NEAREST, moderngl.NEAREST)
+                    texture.filter = (cast(int, moderngl.NEAREST), cast(int, moderngl.NEAREST))
 
         if linear_mipmap_filtering is not None:
-            if texture.filter[0] >= moderngl.NEAREST_MIPMAP_NEAREST:
+            if texture.filter[0] >= cast(int, moderngl.NEAREST_MIPMAP_NEAREST):
                 # Texture has mipmaps
-                linear = texture.filter[1] == moderngl.LINEAR
+                linear = texture.filter[1] == cast(int, moderngl.LINEAR)
                 if linear:
-                    texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR if linear_mipmap_filtering else
-                                      moderngl.LINEAR_MIPMAP_NEAREST, moderngl.LINEAR)
+                    texture.filter = (cast(int, moderngl.LINEAR_MIPMAP_LINEAR if linear_mipmap_filtering else
+                                      moderngl.LINEAR_MIPMAP_NEAREST),
+                                      cast(int, moderngl.LINEAR))
                 else:
-                    texture.filter = (moderngl.NEAREST_MIPMAP_LINEAR if linear_mipmap_filtering else
-                                      moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
+                    texture.filter = (cast(int, moderngl.NEAREST_MIPMAP_LINEAR if linear_mipmap_filtering else
+                                      moderngl.NEAREST_MIPMAP_NEAREST),
+                                      cast(int, moderngl.NEAREST))
 
         if anisotropy is not None:
             if 1 < anisotropy < 16:

--- a/pySSV/ssv_render_opengl.py
+++ b/pySSV/ssv_render_opengl.py
@@ -1,8 +1,8 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 import logging
 import time
-from typing import Optional, Any, Union
+from typing import Optional, Any, Union, Tuple, Set, Dict, List
 from dataclasses import dataclass
 
 import moderngl
@@ -16,10 +16,14 @@ from .ssv_texture import determine_texture_shape
 
 # Optional support for pyRenderdocApp
 try:
-    from pyRenderdocApp import load_render_doc, RENDERDOC_API_1_6_0
+    from pyRenderdocApp import load_render_doc, RENDERDOC_API_1_6_0  # type: ignore
 except ImportError:
-    RENDERDOC_API_1_6_0 = None
-    load_render_doc = lambda: None
+    class RENDERDOC_API_1_6_0:  # type: ignore[no-redef]
+        ...
+
+
+    def load_render_doc(renderdoc_path: Optional[str] = None) -> RENDERDOC_API_1_6_0:  # type: ignore[no-redef]
+        return RENDERDOC_API_1_6_0()
 
 PRIMITIVE_TYPES = {
     "POINTS": moderngl.POINTS,
@@ -46,7 +50,7 @@ class SSVDrawCall:
     order: int
     vertex_buffer: Optional[moderngl.Buffer]
     index_buffer: Optional[moderngl.Buffer]
-    vertex_attributes: tuple[str, ...]
+    vertex_attributes: Tuple[str, ...]
     gl_vertex_array: Optional[moderngl.VertexArray]
     shader_program: Optional[moderngl.Program]
     primitive_type: int
@@ -62,10 +66,14 @@ class SSVDrawCall:
 
     def release(self, needs_gc: bool):
         if needs_gc:
-            self.gl_vertex_array.release()
-            self.vertex_buffer.release()
-            self.index_buffer.release()
-            self.shader_program.release()
+            if self.gl_vertex_array is not None:
+                self.gl_vertex_array.release()
+            if self.vertex_buffer is not None:
+                self.vertex_buffer.release()
+            if self.index_buffer is not None:
+                self.index_buffer.release()
+            if self.shader_program is not None:
+                self.shader_program.release()
 
 
 @dataclass
@@ -77,7 +85,7 @@ class SSVRenderBufferOpenGL:
     needs_gc: bool
     frame_buffer: moderngl.Framebuffer
     render_texture: moderngl.Texture
-    draw_calls: dict[int, SSVDrawCall]
+    draw_calls: Dict[int, SSVDrawCall]
     uniform_name: str
 
     def release(self):
@@ -123,9 +131,9 @@ class SSVRenderOpenGL(SSVRender):
     )
 
     def __init__(self, use_renderdoc_api: bool = False):
-        self._render_buffers: dict[int, SSVRenderBufferOpenGL] = {}
-        self._ordered_render_buffers: list[SSVRenderBufferOpenGL] = []
-        self._texture_objects: dict[int, SSVTextureOpenGL] = {}
+        self._render_buffers: Dict[int, SSVRenderBufferOpenGL] = {}
+        self._ordered_render_buffers: List[SSVRenderBufferOpenGL] = []
+        self._texture_objects: Dict[int, SSVTextureOpenGL] = {}
         self._renderdoc_api = None
         self._renderdoc_is_capturing = False
         if use_renderdoc_api:
@@ -146,6 +154,7 @@ class SSVRenderOpenGL(SSVRender):
         if ENVIRONMENT == Env.COLAB:
             # TODO: Test if any other platforms require specific backends
             # In Google Colab we need to explicitly specify the EGL backend, otherwise it tries (and fails) to use X11
+            # noinspection PyTypeChecker
             self.ctx = moderngl.create_context(standalone=True, backend="egl")
         else:
             # Otherwise let ModernGL try to automatically determine the correct backend
@@ -160,7 +169,8 @@ class SSVRenderOpenGL(SSVRender):
         self.ctx.depth_func = "<="
         self.ctx.enable(moderngl.BLEND)
         # A bit of a weird blending function, but it plays 'nice' with the GUI...
-        self.ctx.blend_func = (moderngl.SRC_ALPHA, moderngl.ONE_MINUS_SRC_ALPHA, moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA)
+        self.ctx.blend_func = (moderngl.SRC_ALPHA, moderngl.ONE_MINUS_SRC_ALPHA,
+                               moderngl.ONE, moderngl.ONE_MINUS_SRC_ALPHA)
         self.ctx.blend_equation = moderngl.FUNC_ADD  # , moderngl.MAX
 
     def log_context_info(self, full=False):
@@ -180,13 +190,13 @@ class SSVRenderOpenGL(SSVRender):
             extensions = pformat(self.ctx.extensions, indent=4)
             log(f"GL Extensions: \n{extensions}", severity=logging.INFO)
 
-    def get_context_info(self) -> dict[str, str]:
+    def get_context_info(self) -> Dict[str, str]:
         return self.ctx.info
 
-    def get_supported_extensions(self) -> set[str]:
+    def get_supported_extensions(self) -> Set[str]:
         return self.ctx.extensions
 
-    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: (int, int), uniform_name: str,
+    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: Tuple[int, int], uniform_name: str,
                             components: int = 4, dtype: str = "f1"):
         # TODO: It might make sense to decouple the moderngl dtype from our dtype if this is meant to be used by an
         #  abstract class.
@@ -231,7 +241,7 @@ class SSVRenderOpenGL(SSVRender):
                        uniform_name: str, value: Any):
         def update_internal(program: moderngl.Program):
             if program is not None and uniform_name in program:
-                program[uniform_name].value = value
+                program[uniform_name].value = value  # type: ignore
 
         if frame_buffer_uid is not None and frame_buffer_uid not in self._render_buffers:
             log(f"Couldn't set uniform in render buffer {frame_buffer_uid} as it doesn't exist!",
@@ -240,8 +250,8 @@ class SSVRenderOpenGL(SSVRender):
         if (draw_call_uid is not None and
                 (frame_buffer_uid is None or
                  draw_call_uid not in self._render_buffers[frame_buffer_uid].draw_calls)):
-            log(f"Couldn't set uniform in draw call {draw_call_uid} for render buffer {frame_buffer_uid} as it doesn't exist!",
-                severity=logging.ERROR)
+            log(f"Couldn't set uniform in draw call {draw_call_uid} for render buffer {frame_buffer_uid} as it "
+                f"doesn't exist!", severity=logging.ERROR)
             return
 
         # Based on whether a frame buffer and/or vertex buffer are specified we either update the uniform
@@ -249,16 +259,18 @@ class SSVRenderOpenGL(SSVRender):
         # TODO: For high-performance scenarios we could probably improve performance by using uniform blocks
         if frame_buffer_uid is not None:
             if draw_call_uid is not None:
-                update_internal(self._render_buffers[frame_buffer_uid].draw_calls[draw_call_uid].shader_program)
+                shader = self._render_buffers[frame_buffer_uid].draw_calls[draw_call_uid].shader_program
+                update_internal(shader)  # type: ignore
             else:
-                [update_internal(vb.shader_program) for vb in
+                [update_internal(vb.shader_program) for vb in  # type: ignore
                  self._render_buffers[frame_buffer_uid].draw_calls.values()]
         else:
-            [update_internal(vb.shader_program) for rb in self._ordered_render_buffers for vb in rb.draw_calls.values()]
+            [update_internal(vb.shader_program)  # type: ignore
+             for rb in self._ordered_render_buffers for vb in rb.draw_calls.values()]
 
     def update_vertex_buffer(self, frame_buffer_uid: int, draw_call_uid: int,
                              vertex_array: Optional[npt.NDArray], index_array: Optional[npt.NDArray],
-                             vertex_attributes: Optional[tuple[str]]):
+                             vertex_attributes: Optional[Tuple[str]]):
         if frame_buffer_uid not in self._render_buffers:
             log(f"Attempted to update the vertex buffer for a non-existant render buffer (id={frame_buffer_uid})!",
                 severity=logging.ERROR)
@@ -270,7 +282,8 @@ class SSVRenderOpenGL(SSVRender):
             draw_call.order = 0
             draw_call.shader_program = None
             self._render_buffers[frame_buffer_uid].draw_calls[draw_call_uid] = draw_call
-            draw_call.vertex_buffer = self._default_vertex_buffer if vertex_array is None else self.ctx.buffer(vertex_array)
+            draw_call.vertex_buffer = (self._default_vertex_buffer if vertex_array is None else
+                                       self.ctx.buffer(vertex_array))
             draw_call.index_buffer = None if index_array is None else self.ctx.buffer(index_array)
         else:
             # Update an existing draw call
@@ -278,24 +291,26 @@ class SSVRenderOpenGL(SSVRender):
             if (vertex_array is not None
                     and draw_call.vertex_buffer is not None
                     and not isinstance(draw_call.vertex_buffer.mglo, moderngl.InvalidObject)
-                    and draw_call.vertex_buffer.size == len(vertex_array)*vertex_array.dtype.itemsize):
+                    and draw_call.vertex_buffer.size == len(vertex_array) * vertex_array.dtype.itemsize):
                 draw_call.vertex_buffer.write(vertex_array)
             else:
                 if draw_call.vertex_buffer is not None:
                     draw_call.vertex_buffer.release()
-                draw_call.vertex_buffer = self._default_vertex_buffer if vertex_array is None else self.ctx.buffer(vertex_array)
+                draw_call.vertex_buffer = (self._default_vertex_buffer if vertex_array is None else
+                                           self.ctx.buffer(vertex_array))
 
             if (index_array is not None
                     and draw_call.index_buffer is not None
                     and not isinstance(draw_call.index_buffer.mglo, moderngl.InvalidObject)
-                    and draw_call.index_buffer.size == len(index_array)*index_array.dtype.itemsize):
+                    and draw_call.index_buffer.size == len(index_array) * index_array.dtype.itemsize):
                 draw_call.index_buffer.write(index_array)
             else:
                 if draw_call.index_buffer is not None:
                     draw_call.index_buffer.release()
                 draw_call.index_buffer = None if index_array is None else self.ctx.buffer(index_array)
 
-        draw_call.vertex_attributes = self._default_vertex_buffer_vertex_attributes if vertex_attributes is None else vertex_attributes
+        draw_call.vertex_attributes = (self._default_vertex_buffer_vertex_attributes if vertex_attributes is None else
+                                       vertex_attributes)
         try:
             if draw_call.shader_program is not None:
                 if draw_call.gl_vertex_array is not None:
@@ -366,7 +381,7 @@ class SSVRenderOpenGL(SSVRender):
 
     def update_texture(self, texture_uid: int, data: npt.NDArray, uniform_name: Optional[str],
                        override_dtype: Optional[str],
-                       rect: Optional[Union[tuple[int, int, int, int], tuple[int, int, int, int, int, int]]],
+                       rect: Optional[Union[Tuple[int, int, int, int], Tuple[int, int, int, int, int, int]]],
                        treat_as_normalized_integer: bool):
         if texture_uid not in self._texture_objects:
             # Try to determine the shape of the texture to create
@@ -426,7 +441,8 @@ class SSVRenderOpenGL(SSVRender):
             old_filter = texture.filter
             if old_filter[0] >= moderngl.NEAREST_MIPMAP_NEAREST:
                 # Texture has mipmaps
-                mipmap = old_filter[0] == moderngl.LINEAR_MIPMAP_LINEAR or old_filter[0] == moderngl.NEAREST_MIPMAP_LINEAR
+                mipmap = (old_filter[0] == moderngl.LINEAR_MIPMAP_LINEAR
+                          or old_filter[0] == moderngl.NEAREST_MIPMAP_LINEAR)
                 if linear_filtering:
                     texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR if mipmap else moderngl.LINEAR_MIPMAP_NEAREST,
                                       moderngl.LINEAR)
@@ -445,15 +461,15 @@ class SSVRenderOpenGL(SSVRender):
                 # Texture has mipmaps
                 linear = texture.filter[1] == moderngl.LINEAR
                 if linear:
-                    texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR if linear_mipmap_filtering else moderngl.LINEAR_MIPMAP_NEAREST,
-                                      moderngl.LINEAR)
+                    texture.filter = (moderngl.LINEAR_MIPMAP_LINEAR if linear_mipmap_filtering else
+                                      moderngl.LINEAR_MIPMAP_NEAREST, moderngl.LINEAR)
                 else:
-                    texture.filter = (moderngl.NEAREST_MIPMAP_LINEAR if linear_mipmap_filtering else moderngl.NEAREST_MIPMAP_NEAREST,
-                                      moderngl.NEAREST)
+                    texture.filter = (moderngl.NEAREST_MIPMAP_LINEAR if linear_mipmap_filtering else
+                                      moderngl.NEAREST_MIPMAP_NEAREST, moderngl.NEAREST)
 
         if anisotropy is not None:
             if 1 < anisotropy < 16:
-                texture.anisotropy = float(anisotropy)
+                texture.anisotropy = float(anisotropy)  # type: ignore
             else:
                 log(f"Texture anisotropy must be between 1 and 16. (got: {anisotropy})", logging.WARN)
 
@@ -466,15 +482,15 @@ class SSVRenderOpenGL(SSVRender):
         # Bind all the render buffers
         for fb in self._render_buffers.values():
             if fb.uniform_name in program:
-                program[fb.uniform_name].value = image_unit
-                fb.frame_buffer.color_attachments[0].use(image_unit)
+                program[fb.uniform_name].value = image_unit  # type: ignore
+                fb.render_texture.use(image_unit)  # type: ignore
                 image_unit += 1
         # Bind all the user textures
         # log(f"Textures: [{', '.join([x.uniform_name for x in self._texture_objects.values()])}]; "
         #     f"Program uniforms: [{', '.join([x for x in program._members.keys()])}]", severity=logging.INFO)
         for texture in self._texture_objects.values():
             if texture.uniform_name in program:
-                program[texture.uniform_name].value = image_unit
+                program[texture.uniform_name].value = image_unit  # type: ignore
                 texture.texture.use(image_unit)
                 image_unit += 1
 

--- a/pySSV/ssv_render_process_server.py
+++ b/pySSV/ssv_render_process_server.py
@@ -13,6 +13,7 @@ from typing import Optional, Dict, Set
 
 import av  # type: ignore
 import numpy as np
+import numpy.typing as npt
 from PIL import Image
 
 from . import ssv_logging
@@ -491,7 +492,7 @@ class SSVRenderProcessServer:
 
         # img = Image.frombytes("RGB", self.output_size, frame)
         # av_frame = av.VideoFrame.from_image(img)
-        frame_np = np.array(frame, copy=False, dtype=np.uint8)
+        frame_np: npt.NDArray[np.uint8] = np.array(frame, copy=False, dtype=np.uint8)
         frame_np = frame_np.reshape((self.output_size[1], self.output_size[0], 3))
         av_frame = av.VideoFrame.from_ndarray(frame_np, format="rgb24")
         packets = self._video_stream.encode(av_frame)

--- a/pySSV/ssv_render_widget.py
+++ b/pySSV/ssv_render_widget.py
@@ -1,21 +1,26 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 
-from ipywidgets import DOMWidget, CallbackDispatcher
-from io import StringIO
-from typing import NewType, Callable
-from traitlets import Unicode, Enum, Int, Bool, Float, Bytes
+from ipywidgets import DOMWidget, CallbackDispatcher  # type: ignore
+from io import TextIOBase
+from typing import Callable
+import sys
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+from traitlets import Unicode, Enum, Int, Bool, Float, Bytes  # type: ignore
 from ._frontend import module_name, module_version
 from .ssv_render_process_server import SSVStreamingMode
 
 
-OnMessageDelegate = NewType("OnMessageDelegate", Callable[[], None])
-OnClickDelegate = NewType("OnClickDelegate", Callable[[bool, int], None])
-OnKeyDelegate = NewType("OnKeyDelegate", Callable[[str, bool], None])
-OnWheelDelegate = NewType("OnWheelDelegate", Callable[[float], None])
+OnMessageDelegate: TypeAlias = Callable[[], None]
+OnClickDelegate: TypeAlias = Callable[[bool, int], None]
+OnKeyDelegate: TypeAlias = Callable[[str, bool], None]
+OnWheelDelegate: TypeAlias = Callable[[float], None]
 
 
 class SSVRenderWidget(DOMWidget):
@@ -141,7 +146,7 @@ class SSVRenderWidget(DOMWidget):
         self._renderdoc_capture_handlers.register_callback(callback, remove=remove)
 
 
-class SSVRenderWidgetLogIO(StringIO):
+class SSVRenderWidgetLogIO(TextIOBase):
     def __init__(self, widget: SSVRenderWidget):
         self._widget = widget
 

--- a/pySSV/ssv_shader_args_tokenizer.py
+++ b/pySSV/ssv_shader_args_tokenizer.py
@@ -1,13 +1,13 @@
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
-from typing import Any
+from typing import Any, List
 
-import pcpp
+import pcpp  # type: ignore
 
 
 class SSVShaderArgsTokenizer:
     @staticmethod
-    def correct_tokens(tokens: list[Any], preprocessor: pcpp.Preprocessor):
+    def correct_tokens(tokens: List[Any], preprocessor: pcpp.Preprocessor):
         """
         This method takes a list of PCPP LexTokens and converts them to a list of arguments for argparse.
 

--- a/pySSV/tests/conftest.py
+++ b/pySSV/tests/conftest.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-#  Copyright (c) 2023 Thomas Mathieson.
+#  Copyright (c) 2023-2024 Thomas Mathieson.
 #  Distributed under the terms of the MIT license.
 
 import pytest
 
 from ipykernel.comm import Comm
-from ipywidgets import Widget
+from ipywidgets import Widget  # type: ignore
+
 
 class MockComm(Comm):
     """A mock Comm object.
@@ -15,7 +16,7 @@ class MockComm(Comm):
     Can be used to inspect calls to Comm's open/send/close methods.
     """
     comm_id = 'a-b-c-d'
-    kernel = 'Truthy'
+    kernel = 'Truthy'  # type: ignore
 
     def __init__(self, *args, **kwargs):
         self.log_open = []
@@ -32,6 +33,7 @@ class MockComm(Comm):
     def close(self, *args, **kwargs):
         self.log_close.append((args, kwargs))
 
+
 _widget_attrs = {}
 undefined = object()
 
@@ -41,8 +43,10 @@ def mock_comm():
     _widget_attrs['_comm_default'] = getattr(Widget, '_comm_default', undefined)
     Widget._comm_default = lambda self: MockComm()
     _widget_attrs['_ipython_display_'] = Widget._ipython_display_
+
     def raise_not_implemented(*args, **kwargs):
         raise NotImplementedError()
+
     Widget._ipython_display_ = raise_not_implemented
 
     yield MockComm()

--- a/pySSV/tests/conftest.py
+++ b/pySSV/tests/conftest.py
@@ -15,7 +15,7 @@ class MockComm(Comm):
 
     Can be used to inspect calls to Comm's open/send/close methods.
     """
-    comm_id = 'a-b-c-d'
+    comm_id = 'a-b-c-d'  # type: ignore
     kernel = 'Truthy'  # type: ignore
 
     def __init__(self, *args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,13 @@ dependencies = [
     "numpy>=1.22.0; python_version<='3.10'",
     "numpy>=1.24.0; python_version=='3.11'",
     "numpy>=1.26.0; python_version=='3.12'",
-    "moderngl>=5.8.2",
-    "Pillow>=10.1.0",
-    "pcpp==1.30",
-    "av==11.0.0",
-    "portpicker==1.6.0",
-    "websockets==12.0"
+    "moderngl~=5.8.2",
+    "Pillow~=10.1.0",
+    "types-Pillow~=10.1.0",
+    "pcpp~=1.30",
+    "av~=11.0.0",
+    "portpicker~=1.6.0",
+    "websockets~=12.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Thomas Mathieson.
+ * Copyright (c) 2023-2024 Thomas Mathieson.
  * Distributed under the terms of the MIT license.
  */
 
@@ -251,10 +251,19 @@ export class SSVRenderView extends DOMWidgetView {
       }
     );
     this._stream_element.addEventListener(
+      "contextmenu",
+      (event: Event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    );
+    this._stream_element.addEventListener(
       "mousedown",
       (event: Event) => {
         const evt = event as MouseEvent;
         this.send({"mousedown": evt.button});
+        evt.preventDefault();
+        evt.stopPropagation();
       }
     );
     this._stream_element.addEventListener(
@@ -262,6 +271,8 @@ export class SSVRenderView extends DOMWidgetView {
       (event: Event) => {
         const evt = event as MouseEvent;
         this.send({"mouseup": evt.button});
+        evt.preventDefault();
+        evt.stopPropagation();
       }
     );
     this._stream_element.addEventListener(
@@ -276,10 +287,10 @@ export class SSVRenderView extends DOMWidgetView {
         this._focussed = false;
       }
     );
-    window.addEventListener("keypress", this.on_keypress);
-    window.addEventListener("keydown", this.on_keydown);
-    window.addEventListener("keyup", this.on_keyup);
-    window.addEventListener("wheel", this.on_wheel, {passive: false});
+    document.addEventListener("keypress", this.on_keypress, {capture: true});
+    document.addEventListener("keydown", this.on_keydown, {capture: true});
+    document.addEventListener("keyup", this.on_keyup, {capture: true});
+    document.addEventListener("wheel", this.on_wheel, {passive: false});
   }
 
   private on_keypress = (event: KeyboardEvent) => {


### PR DESCRIPTION
 - Turns out Python 3.8 compatibility has been broken for a while
 - Replaced all incompatible type hints with Python 3.8 compatible ones
 - The project now passes mypy static type analysis
 - Added mypy checking to the GitHub actions
 - Fixed many code inspection/style issues
 - Incremented version number
 - Updated dependencies to use compatible versions
 - Fixed keyboard movement for cameras
 - Delegate types are now better recognised by type hinters
 - on_frame_rendered now exposes delta_time (and actually gets called...)
 - Added more None checks where needed; there are no more implicit Nones
 - Fixed some bugs with the SSVStreamingMode enum and related code
 - importlib.resources code is now Python 3.8 compatible
 - SSVGUI now correctly rounds Rect values to ints where needed
 - Added new label_3d() method to SSVGUI to draw world space transformed labels (experimental)
 - The render process now uses spawn instead of fork on Unix
 - Added contextmenu event hook to the TS widget