### PR TITLE
Improved OpenGL context creation on Linux:

### DIFF
--- a/pySSV/__init__.py
+++ b/pySSV/__init__.py
@@ -35,13 +35,16 @@ def _jupyter_nbextension_paths():
 
 # Various factory methods
 
-def canvas(size: Optional[Tuple[int, int]] = (640, 480), backend: str = "opengl", standalone: bool = False,
-           target_framerate: int = 60, use_renderdoc: bool = False, supports_line_directives: Optional[bool] = None):
+def canvas(size: Optional[Tuple[int, int]] = (640, 480), backend: str = "opengl",
+           gl_version: Optional[Tuple[int, int]] = None, standalone: bool = False, target_framerate: int = 60,
+           use_renderdoc: bool = False, supports_line_directives: Optional[bool] = None):
     """
     Creates a new ``SSVCanvas`` which contains the render widget and manages the render context.
 
     :param size: the default resolution of the renderer as a tuple: ``(width: int, height: int)``.
     :param backend: the rendering backend to use; currently supports: ``"opengl"``.
+    :param gl_version: optionally, the minimum version of OpenGL to support. Accepts a tuple of (major, minor), eg:
+                       gl_version=(4, 2) for OpenGL 4.2 Core.
     :param standalone: whether the canvas should run standalone, or attempt to create a Jupyter Widget for
                        rendering.
     :param target_framerate: the default framerate to target when running.
@@ -53,4 +56,4 @@ def canvas(size: Optional[Tuple[int, int]] = (640, 480), backend: str = "opengl"
                                      ``False``.
     """
 
-    return SSVCanvas(size, backend, standalone, target_framerate, use_renderdoc, supports_line_directives)
+    return SSVCanvas(size, backend, gl_version, standalone, target_framerate, use_renderdoc, supports_line_directives)

--- a/pySSV/ssv_render.py
+++ b/pySSV/ssv_render.py
@@ -24,7 +24,13 @@ class SSVRender(ABC):
     """
 
     @abstractmethod
-    def __init__(self):
+    def __init__(self, gl_version: Optional[int] = None, use_renderdoc_api: bool = False):
+        """
+        Initialises a new renderer (and backing graphics context) with the given options.
+
+        :param gl_version: optionally, the minimum version of OpenGL to support.
+        :param use_renderdoc_api: whether the renderer should attempt to load the RenderDoc API.
+        """
         ...
 
     @abstractmethod

--- a/pySSV/ssv_render_process_client.py
+++ b/pySSV/ssv_render_process_client.py
@@ -30,11 +30,13 @@ class SSVRenderProcessClient:
     ``SSVRenderProcessServer``).
     """
 
-    def __init__(self, backend: str, timeout: Optional[float] = 1, use_renderdoc_api: bool = False):
+    def __init__(self, backend: str, gl_version: Optional[int] = None, timeout: Optional[float] = 1,
+                 use_renderdoc_api: bool = False):
         """
         Initialises a new Render Process Client and starts the render process.
 
         :param backend: the rendering backend to use.
+        :param gl_version: optionally, the minimum version of OpenGL to support.
         :param timeout: the render process watchdog timeout, set to None to disable.
         :param use_renderdoc_api: whether the renderdoc_api should be initialised.
         """
@@ -59,7 +61,7 @@ class SSVRenderProcessClient:
         # (note that the rx and tx queues are flipped here, the rx queue of the server is the tx queue of the client)
         self._render_process = Process(target=SSVRenderProcessServer, daemon=True,
                                        name=f"SSV Render Process - {id(self):#08x}",
-                                       args=(backend, self._command_queue_rx, self._command_queue_tx,
+                                       args=(backend, gl_version, self._command_queue_rx, self._command_queue_tx,
                                              ssv_logging.get_severity(), timeout, use_renderdoc_api))
         self._render_process.start()
         self._is_alive = True

--- a/pySSV/ssv_render_process_server.py
+++ b/pySSV/ssv_render_process_server.py
@@ -60,8 +60,8 @@ class SSVRenderProcessServer:
     in a dedicated process by SSVRenderProcessClient.
     """
 
-    def __init__(self, backend: str, command_queue_tx: Queue, command_queue_rx: Queue, log_severity: int,
-                 timeout: Optional[float], use_renderdoc_api: bool = False):
+    def __init__(self, backend: str, gl_version: Optional[int], command_queue_tx: Queue,
+                 command_queue_rx: Queue, log_severity: int, timeout: Optional[float], use_renderdoc_api: bool = False):
         self._renderer: Optional[SSVRender] = None
         self._command_queue_tx: Queue = command_queue_tx
         self._command_queue_rx: Queue = command_queue_rx
@@ -91,7 +91,7 @@ class SSVRenderProcessServer:
         self.max_delta_time_encode = 1 / self.target_framerate
 
         self.__init_video_encoder()
-        self.__init_render_process(backend)
+        self.__init_render_process(backend, gl_version)
 
     _supported_video_formats: Set[SSVStreamingMode] = {
         SSVStreamingMode.H264,
@@ -186,14 +186,14 @@ class SSVRenderProcessServer:
         log_stream = SSVRenderProcessLogger(self._command_queue_tx)
         ssv_logging.set_output_stream(log_stream, level=log_severity, prefix="pySSV_Render")
 
-    def __init_render_process(self, backend: str):
+    def __init_render_process(self, backend: str, gl_version: Optional[int]):
         """
         Creates a new renderer for the given backend and starts the render process loop.
 
         :param backend: the render backend to use.
         """
         if backend == "opengl":
-            self._renderer = SSVRenderOpenGL(self._use_renderdoc_api)
+            self._renderer = SSVRenderOpenGL(gl_version, self._use_renderdoc_api)
         else:
             self._renderer = None
             log(f"Backend '{backend}' does not exist!", logging.ERROR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy>=1.22.0; python_version<='3.10'",
     "numpy>=1.24.0; python_version=='3.11'",
     "numpy>=1.26.0; python_version=='3.12'",
-    "moderngl~=5.8.2",
+    "moderngl~=5.10.0",
     "Pillow~=10.1.0",
     "types-Pillow~=10.1.0",
     "pcpp~=1.30",


### PR DESCRIPTION
 - OpenGL version is now specifiable when creating a canvas
 - The shader preprocessor now attempts to use the GL version specified in the GLContext info
 - Updated moderngl
 - Under WSL, context creation now defaults to using the first NVIDIA gpu in the system if available