### PR TITLE
Fixes and small features:

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Individual Project at the University of Glasgow for my Computing Science degree.
 The dissertation and accompanying notes and planning documents can be found
 [here](https://github.com/space928/Shaders-For-Scientific-Visualisation-Notes).
 
+> [!NOTE]  
+> **FEEDBACK WANTED**  
+> To evaluate the utility of this project for my dissertation, I would appreciate if you could spare some time to fill 
+> out this survey:
+> 
+> https://forms.gle/rX7uPxaxQ1xcNVQB8
+
 ## Gallery
 
 [![image](https://github.com/space928/Shaders-For-Scientific-Visualisation/assets/15130114/8135a39e-68c4-4a05-b851-a5fd01ff61db)](https://pyssv.readthedocs.io/en/latest/examples/introduction.html#Mouse-input)|[![image](https://github.com/space928/Shaders-For-Scientific-Visualisation/assets/15130114/a6f314f4-d364-4e77-8f46-d64a4acb175d)](https://pyssv.readthedocs.io/en/latest/examples/introduction.html#Shader-Templates)|[![image](https://github.com/space928/Shaders-For-Scientific-Visualisation/assets/15130114/bc7b0fac-b832-4b71-a04b-7e7dc5a3a660)](https://pyssv.readthedocs.io/en/latest/examples/gui_examples.html)

--- a/css/widget.css
+++ b/css/widget.css
@@ -113,6 +113,65 @@
   background-color: var(--ssv-bg-color2);
 }
 
+.ssv-combi-button-left {
+  border-end-end-radius: 0 !important;
+  border-start-end-radius: 0 !important;
+  margin-right: 0 !important;
+}
+
+.ssv-combi-button-centre {
+  border-radius: 0 !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+}
+
+.ssv-combi-button-right {
+  border-start-start-radius: 0 !important;
+  border-end-start-radius: 0 !important;
+  margin-left: 0 !important;
+}
+
+[class^="ssv-input"] {
+  height: 1.5rem !important;
+  padding: 0 0.5rem;
+  margin-right: 2px;
+  font-family: sans-serif;
+}
+
+[class^="ssv-input"]:disabled {
+  opacity: 75%;
+}
+
+[class^="ssv-input"]:hover:enabled {
+  background-color: var(--ssv-bg-color4);
+}
+
+[class^="ssv-input"]:active:enabled {
+  background-color: var(--ssv-bg-color2);
+}
+
+.ssv-input-select {
+  color: var(--ssv-font-color1);
+  background-color: var(--ssv-bg-color3);
+  border: 1px solid #ffffff10;
+  border-radius: 3px;
+}
+
+.ssv-input-number {
+  color: var(--ssv-font-color1);
+  background-color: var(--ssv-bg-color3);
+  border: 1px solid #ffffff10;
+  border-radius: 3px;
+}
+
+.ssv-input-checkbox {
+
+}
+
+.ssv-input-slider {
+  padding: 0 !important;
+}
+
 .ssv-status-frame-stats table {
   display: contents;
 }
@@ -128,4 +187,46 @@
 
 .ssv-status-frame-stats td:nth-last-child(n+1) {
   padding-right: 16px;
+}
+
+.ssv-status-save-image {
+  display: flex;
+}
+
+.ssv-modal {
+  position: fixed;
+  z-index: 10;
+  border-radius: 3px;
+  background: var(--ssv-bg-color1);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 2px;
+  box-shadow: 0 6px 16px #0005;
+}
+
+.ssv-modal-title-bar {
+  background: var(--ssv-bg-color2);
+  border-radius: 3px 3px 0 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ssv-modal-item {
+  margin: 4px 8px;
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.ssv-label {
+  margin-right: 5px;
+}
+
+.ssv-hidden {
+  display: none !important;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "py-ssv",
-    "version": "0.6.3",
+    "version": "0.6.5",
     "description": "Leverage the power of shaders for scientific visualisation in Jupyter",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "py-ssv",
-    "version": "0.6.5",
+    "version": "0.7.1",
     "description": "Leverage the power of shaders for scientific visualisation in Jupyter",
     "keywords": [
         "jupyter",

--- a/pySSV/shaders/global_uniforms.glsl
+++ b/pySSV/shaders/global_uniforms.glsl
@@ -1,16 +1,28 @@
 //  Copyright (c) 2023 Thomas Mathieson.
 //  Distributed under the terms of the MIT license.
+/******************************************************************************
+* This file declares all the built in uniforms set by pySSV and any
+* uniforms declared dynamically by the preprocessor.
+******************************************************************************/
 #ifdef SPHINX_DOCS
 // Compatibility hack for the documentation compiler which doesn't know that 'uniform' is a keyword...
 #define uniform
 #endif // SPHINX_DOCS
+/** The time in seconds since the canvas started running. */
 uniform float uTime;
+/** The current frame number, starting from 0. */
 uniform int uFrame;
+/** The resolution of the current render buffer in pixels. */
 uniform vec4 uResolution;
+/** The coordinates of the mouse relative to the canvas in pixels. */
 uniform vec2 uMouse;
+/** Whether the mouse button is pressed. */
 uniform bool uMouseDown;
+/** The main camera's view matrix. */
 uniform mat4x4 uViewMat;
+/** The main camera's projection matrix. */
 uniform mat4x4 uProjMat;
+/** The forward vector of the main camera. */
 uniform vec3 uViewDir;
 
 #ifdef SHADERTOY_COMPAT

--- a/pySSV/shaders/template_ui.glsl
+++ b/pySSV/shaders/template_ui.glsl
@@ -16,6 +16,10 @@
 #include "global_uniforms.glsl"
 
 
+// This uniform allows the UI rendering to be suppressed when enabled
+uniform float _suppress_ui;
+
+
 #ifdef SHADER_STAGE_VERTEX
 layout(location = 0) in vec2 in_vert;
 layout(location = 1) in vec4 in_color;
@@ -49,6 +53,11 @@ void main() {
     #ifdef T_SUPPORT_ROUNDING
     v_size = in_size;
     #endif // T_SUPPORT_ROUNDING
+
+    if(_suppress_ui != 0) {
+        // Put all vertices outside of clip space to prevent them from being rasterised.
+        gl_Position = vec4(-2., 0., 0., 1.);
+    }
 }
 #endif // SHADER_STAGE_VERTEX
 

--- a/pySSV/ssv_gui.py
+++ b/pySSV/ssv_gui.py
@@ -1269,7 +1269,10 @@ def create_gui(canvas: SSVCanvas) -> SSVGUI:
     #pragma SSV pixel mainImage --z_value 0.01
     vec4 mainImage(in vec2 fragCoord)
     {{
-        vec2 uv = fragCoord/uResolution.xy;
+        // Compute UVs which place the UI at it's original resolution in the top left of the screen.
+        // this is needed to prevent UI stretching if the main render buffer is resized.
+        vec2 ui_size = vec2({rb.size[0]}., {rb.size[1]}.);
+        vec2 uv = clamp((fragCoord - vec2(0., uResolution.y-ui_size.y))/ui_size, 0., 1.);
         vec4 col = texture({rb.render_buffer_name}, uv);
         col.rgb /= col.a;
         return col;

--- a/pySSV/ssv_render.py
+++ b/pySSV/ssv_render.py
@@ -54,7 +54,7 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def read_frame_into(self, buffer: bytearray, components: int = 4, frame_buffer_uid: int = 0):
+    def read_frame_into(self, buffer: bytearray, components: int = 4, frame_buffer_uid: int = 0) -> None:
         """
         Gets the current contents of the frame buffer as a byte array.
 
@@ -65,7 +65,7 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def log_context_info(self, full=False):
+    def log_context_info(self, full=False) -> None:
         """
         Logs the OpenGL information to the console for debugging.
 
@@ -89,7 +89,7 @@ class SSVRender(ABC):
 
     @abstractmethod
     def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: Tuple[int, int], uniform_name: str,
-                            components: int = 4, dtype: str = "f1"):
+                            components: int = 4, dtype: str = "f1") -> None:
         """
         Updates the resolution/format of the given frame buffer. Note that framebuffer 0 is always used for output.
         If the given framebuffer id does not exist, it is created.
@@ -105,7 +105,7 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def delete_frame_buffer(self, frame_buffer_uid: int):
+    def delete_frame_buffer(self, frame_buffer_uid: int) -> None:
         """
         Destroys the given framebuffer. *Note* that framebuffer 0 can't be destroyed as it is the output framebuffer.
 
@@ -115,7 +115,7 @@ class SSVRender(ABC):
 
     @abstractmethod
     def update_uniform(self, frame_buffer_uid: Optional[int], draw_call_uid: Optional[int],
-                       uniform_name: str, value: Any):
+                       uniform_name: str, value: Any) -> None:
         """
         Updates the value of a named shader uniform.
 
@@ -131,7 +131,7 @@ class SSVRender(ABC):
     @abstractmethod
     def update_vertex_buffer(self, frame_buffer_uid: int, draw_call_uid: int,
                              vertex_array: Optional[npt.NDArray], index_array: Optional[npt.NDArray],
-                             vertex_attributes: Optional[Tuple[str]]):
+                             vertex_attributes: Optional[Tuple[str]]) -> None:
         """
         Updates the data inside a vertex buffer.
 
@@ -145,7 +145,7 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def delete_vertex_buffer(self, frame_buffer_uid: int, draw_call_uid: int):
+    def delete_vertex_buffer(self, frame_buffer_uid: int, draw_call_uid: int) -> None:
         """
         Deletes an existing vertex buffer.
 
@@ -159,7 +159,7 @@ class SSVRender(ABC):
                         vertex_shader: str, fragment_shader: Optional[str],
                         tess_control_shader: Optional[str], tess_evaluation_shader: Optional[str],
                         geometry_shader: Optional[str], compute_shader: Optional[str],
-                        primitive_type: Optional[str] = None):
+                        primitive_type: Optional[str] = None) -> None:
         """
         Compiles and registers a shader to a given framebuffer.
 
@@ -180,7 +180,7 @@ class SSVRender(ABC):
     def update_texture(self, texture_uid: int, data: npt.NDArray, uniform_name: Optional[str],
                        override_dtype: Optional[str],
                        rect: Optional[Union[Tuple[int, int, int, int], Tuple[int, int, int, int, int, int]]],
-                       treat_as_normalized_integer: bool):
+                       treat_as_normalized_integer: bool) -> None:
         """
         Creates or updates a texture from the NumPy array provided.
 
@@ -200,8 +200,7 @@ class SSVRender(ABC):
     @abstractmethod
     def update_texture_sampler(self, texture_uid: int, repeat_x: Optional[bool], repeat_y: Optional[bool],
                                linear_filtering: Optional[bool], linear_mipmap_filtering: Optional[bool],
-                               anisotropy: Optional[int],
-                               build_mip_maps: bool):
+                               anisotropy: Optional[int], build_mip_maps: bool) -> None:
         """
         Updates a texture's sampling settings. Parameters set to ``None`` are not updated.
 
@@ -218,7 +217,7 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def delete_texture(self, texture_uid: int):
+    def delete_texture(self, texture_uid: int) -> None:
         """
         Destroys the given texture object.
 
@@ -227,10 +226,20 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def renderdoc_capture_frame(self, filename: Optional[str]):
+    def renderdoc_capture_frame(self, filename: Optional[str]) -> None:
         """
         Triggers a frame capture with Renderdoc if it's initialised.
 
         :param filename: optionally, the filename and path to save the capture with.
+        """
+        ...
+
+    @abstractmethod
+    def set_start_time(self, start_time: float) -> None:
+        """
+        Sets the renderer's start time; this is used by the renderer to compute the canvas time which is injected into
+        shaders.
+
+        :param start_time: the start time of the renderer in seconds since the start of the epoch.
         """
         ...

--- a/pySSV/ssv_render.py
+++ b/pySSV/ssv_render.py
@@ -18,6 +18,25 @@ class ShaderStage(Enum):
     COMPUTE = "compute"
 
 
+class SSVStreamingMode(Enum):
+    """
+    Represents an image/video streaming mode for pySSV. Note that some of these streaming formats may not be
+    supported on all platforms.
+    """
+    JPG = "jpg"
+    PNG = "png"
+
+    VP8 = "vp8"
+    VP9 = "vp9"
+    H264 = "h264"
+    HEVC = "hevc"
+    """Not supported"""
+    MPEG4 = "mpeg4"
+    """Not supported"""
+
+    MJPEG = "mjpeg"
+
+
 class SSVRender(ABC):
     """
     An abstract rendering backend for SSV
@@ -88,11 +107,14 @@ class SSVRender(ABC):
         ...
 
     @abstractmethod
-    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: Tuple[int, int], uniform_name: str,
-                            components: int = 4, dtype: str = "f1") -> None:
+    def update_frame_buffer(self, frame_buffer_uid: int, order: Optional[int], size: Optional[Tuple[int, int]],
+                            uniform_name: Optional[str], components: Optional[int] = 4,
+                            dtype: Optional[str] = "f1") -> None:
         """
         Updates the resolution/format of the given frame buffer. Note that framebuffer 0 is always used for output.
         If the given framebuffer id does not exist, it is created.
+
+        Setting a parameter to ``None`` preserves the current value for that frame buffer.
 
         :param frame_buffer_uid: the uid of the framebuffer to update/create. Buffer 0 is the output framebuffer.
         :param order: the sorting order to render the frame buffers in, smaller values are rendered first.

--- a/pySSV/ssv_render_opengl.py
+++ b/pySSV/ssv_render_opengl.py
@@ -236,8 +236,21 @@ class SSVRenderOpenGL(SSVRender):
     def get_supported_extensions(self) -> Set[str]:
         return self.ctx.extensions
 
-    def update_frame_buffer(self, frame_buffer_uid: int, order: int, size: Tuple[int, int], uniform_name: str,
-                            components: int = 4, dtype: str = "f1"):
+    def update_frame_buffer(self, frame_buffer_uid: int, order: Optional[int], size: Optional[Tuple[int, int]],
+                            uniform_name: Optional[str], components: Optional[int] = 4, dtype: Optional[str] = "f1"):
+        if frame_buffer_uid not in self._render_buffers:
+            if order is None or size is None or uniform_name is None or components is None or dtype is None:
+                log("Attempted to update a non-existant frame buffer! When creating a new frame buffer, no "
+                    "arguments can be set to None.", severity=logging.ERROR)
+                return
+        else:
+            old_rb = self._render_buffers[frame_buffer_uid]
+            order = old_rb.order if order is None else order
+            size = old_rb.render_texture.size if size is None else size
+            uniform_name = old_rb.uniform_name if uniform_name is None else uniform_name
+            components = old_rb.render_texture.components if components is None else components
+            dtype = old_rb.render_texture.dtype if dtype is None else dtype
+
         # TODO: It might make sense to decouple the moderngl dtype from our dtype if this is meant to be used by an
         #  abstract class.
         resolution = (min(size[0], self.ctx.info["GL_MAX_VIEWPORT_DIMS"][0]),

--- a/pySSV/ssv_render_process_server.py
+++ b/pySSV/ssv_render_process_server.py
@@ -365,6 +365,9 @@ class SSVRenderProcessServer:
         elif command == "RdCp":
             # Renderdoc Capture frame
             self._renderer.renderdoc_capture_frame(*command_args)
+        elif command == "StTm":
+            # Set start Time
+            self._renderer.set_start_time(*command_args)
         elif command == "LogC":
             # Log Context Info
             self._renderer.log_context_info(command_args[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ docs = [
     "recommonmark",
     "sphinx>=1.5",
     "sphinx_rtd_theme",
+    "clang~=14.0.0",
     "sphinx-c-autodoc"
 ]
 examples = []

--- a/src/widget_save_image_settings.ts
+++ b/src/widget_save_image_settings.ts
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2024 Thomas Mathieson.
+ * Distributed under the terms of the MIT license.
+ */
+
+import {DOMWidgetView} from "@jupyter-widgets/base";
+
+enum SSVImageType {
+  JPG = "jpg",
+  PNG = "png"
+}
+
+type SSVSaveImageSettings = {
+  image_type: SSVImageType,
+  quality: number,
+  size: { width: number, height: number } | null,
+  render_buffer: number,
+  suppress_ui: boolean
+}
+
+class SSVWidgetSaveImageSettingsPanel {
+  // @ts-ignore
+  private _widget_view: DOMWidgetView;
+  // @ts-ignore
+  private _widget_root_element: HTMLElement;
+  private readonly _save_image_settings: SSVSaveImageSettings;
+  private _hidden: boolean = true;
+  private _settings_panel_element: HTMLDivElement | null = null;
+
+  public constructor(widget: DOMWidgetView, root: HTMLElement) {
+    this._widget_view = widget;
+    this._widget_root_element = root;
+    this._save_image_settings = {
+      image_type: SSVImageType.JPG,
+      quality: 95,
+      size: null,
+      render_buffer: 0,
+      suppress_ui: false
+    };
+  }
+
+  get save_image_settings(): SSVSaveImageSettings {
+    return this._save_image_settings;
+  }
+
+  get hidden(): boolean {
+    return this._hidden;
+  }
+
+  set hidden(value: boolean) {
+    this._hidden = value;
+    if(value)
+      this._settings_panel_element?.classList.add("ssv-hidden");
+    else
+      this._settings_panel_element?.classList.remove("ssv-hidden");
+  }
+
+  public render(parent_element: HTMLElement) {
+    this._settings_panel_element = document.createElement("div");
+    this._settings_panel_element.classList.add("ssv-modal", "ssv-hidden");
+    parent_element.appendChild(this._settings_panel_element);
+    this._settings_panel_element.style.translate = `0 2.4rem`;  // This is a lazy approach, but it works for now
+    this._settings_panel_element.style.width = "20rem";
+    // this._settings_panel_element.style.height = "20rem";
+
+    const title_bar = document.createElement("span");
+    title_bar.className = "ssv-modal-title-bar";
+    this._settings_panel_element.appendChild(title_bar);
+    const title_bar_label = document.createElement("label");
+    title_bar_label.style.paddingLeft = "14px";
+    title_bar_label.style.fontWeight = "bold";
+    title_bar_label.innerText = "Image Settings";
+    title_bar.appendChild(title_bar_label);
+
+    // Close button
+    const close_button = document.createElement("button");
+    close_button.textContent = "❌";
+    close_button.className = "ssv-button ssv-icon-button";
+    close_button.style.marginRight = "0";
+    close_button.onclick = () => {
+      this.hidden = true;
+    };
+    title_bar.appendChild(close_button);
+
+    // Image type
+    const image_type_span = document.createElement("span");
+    image_type_span.className = "ssv-modal-item";
+    const image_type_label = document.createElement("label");
+    image_type_label.className = "ssv-label";
+    image_type_label.innerText = "Image Type:"
+
+    const image_type_combo = document.createElement("select");
+    image_type_combo.className = "ssv-input-select";
+    for(const v in SSVImageType) {
+      const option = document.createElement("option");
+      option.textContent = v;
+      option.value = v;
+      image_type_combo.appendChild(option);
+    }
+    image_type_combo.onchange = () => {
+      //this._save_image_settings.image_type = image_type_combo.value as SSVImageType;
+      this._save_image_settings.image_type = (SSVImageType as any)[image_type_combo.value];
+    };
+    image_type_span.append(image_type_label, image_type_combo);
+    this._settings_panel_element.appendChild(image_type_span);
+
+    // Quality slider
+    const quality_span = document.createElement("span");
+    quality_span.className = "ssv-modal-item";
+    const quality_label = document.createElement("label");
+    quality_label.className = "ssv-label";
+    quality_label.innerText = "Image Quality:"
+
+    const quality_input = document.createElement("input");
+    quality_input.className = "ssv-input-number";
+    quality_input.style.width = "2rem";
+    quality_input.type = "number";
+    quality_input.min = "0";
+    quality_input.max = "100";
+    quality_input.step = "1";
+    quality_input.valueAsNumber = this._save_image_settings.quality;
+    quality_input.onchange = () => {
+      quality_slider.valueAsNumber = quality_input.valueAsNumber;
+      this._save_image_settings.quality = quality_input.valueAsNumber;
+    };
+
+    const quality_slider = document.createElement("input");
+    quality_slider.className = "ssv-input-slider";
+    quality_slider.style.flexGrow = "1";
+    quality_slider.type = "range";
+    quality_slider.min = "0";
+    quality_slider.max = "100";
+    quality_slider.step = "1";
+    quality_slider.valueAsNumber = this._save_image_settings.quality;
+    quality_slider.oninput = () => {
+      quality_input.valueAsNumber = quality_slider.valueAsNumber;
+      this._save_image_settings.quality = quality_slider.valueAsNumber;
+    };
+    quality_slider.onchange = () => {
+      quality_input.valueAsNumber = quality_slider.valueAsNumber;
+      this._save_image_settings.quality = quality_slider.valueAsNumber;
+    };
+    quality_span.append(quality_label, quality_input, quality_slider);
+    this._settings_panel_element.appendChild(quality_span);
+
+    // Suppress UI
+    const suppress_ui_span = document.createElement("span");
+    suppress_ui_span.className = "ssv-modal-item";
+    const suppress_ui_label = document.createElement("label");
+    suppress_ui_label.className = "ssv-label";
+    suppress_ui_label.innerText = "Suppress SSV GUI:"
+
+    const suppress_ui_toggle = document.createElement("input");
+    suppress_ui_toggle.className = "ssv-input-checkbox";
+    suppress_ui_toggle.type = "checkbox";
+    suppress_ui_toggle.value = `${this._save_image_settings.suppress_ui}`;
+    suppress_ui_toggle.onchange = () => {
+      this._save_image_settings.suppress_ui = suppress_ui_toggle.checked;
+    };
+    suppress_ui_span.append(suppress_ui_label, suppress_ui_toggle);
+    this._settings_panel_element.appendChild(suppress_ui_span);
+
+    // Size enable
+    const size_enable_span = document.createElement("span");
+    size_enable_span.className = "ssv-modal-item";
+    const size_enable_label = document.createElement("label");
+    size_enable_label.className = "ssv-label";
+    size_enable_label.innerText = "Use Custom Resolution:"
+
+    const size_enable_toggle = document.createElement("input");
+    size_enable_toggle.className = "ssv-input-checkbox";
+    size_enable_toggle.type = "checkbox";
+    size_enable_toggle.value = `${this._save_image_settings.size != null}`;
+    size_enable_toggle.onchange = () => {
+      if(size_enable_toggle.checked) {
+        width_input.disabled = false;
+        height_input.disabled = false;
+        this._save_image_settings.size = {width: width_input.valueAsNumber, height: height_input.valueAsNumber};
+      } else {
+        width_input.disabled = true;
+        height_input.disabled = true;
+        this._save_image_settings.size = null;
+      }
+    };
+    size_enable_span.append(size_enable_label, size_enable_toggle);
+    this._settings_panel_element.appendChild(size_enable_span);
+
+    // Size
+    const size_controls_span = document.createElement("span");
+    size_controls_span.className = "ssv-modal-item";
+    const width_control_label = document.createElement("label");
+    width_control_label.className = "ssv-label";
+    width_control_label.innerText = "Width:";
+    const height_control_label = document.createElement("label");
+    height_control_label.className = "ssv-label";
+    height_control_label.innerText = "Height:";
+
+    const width_input = document.createElement("input");
+    width_input.className = "ssv-input-number";
+    width_input.type = "number";
+    width_input.min = "1";
+    width_input.max = "65536";
+    width_input.step = "1";
+    width_input.valueAsNumber = 1920;
+    width_input.onchange = () => {
+        this._save_image_settings.size = {width: width_input.valueAsNumber, height: height_input.valueAsNumber};
+    }
+
+    const height_input = document.createElement("input");
+    height_input.className = "ssv-input-number";
+    height_input.type = "number";
+    height_input.min = "1";
+    height_input.max = "65536";
+    height_input.step = "1";
+    height_input.valueAsNumber = 1080;
+    height_input.onchange = () => {
+        this._save_image_settings.size = {width: width_input.valueAsNumber, height: height_input.valueAsNumber};
+    }
+
+    width_input.disabled = true;
+    height_input.disabled = true;
+    size_controls_span.append(width_control_label, width_input, height_control_label, height_input);
+    this._settings_panel_element.appendChild(size_controls_span);
+
+    // Render Buffer
+    const render_buffer_span = document.createElement("span");
+    render_buffer_span.className = "ssv-modal-item";
+    const render_buffer_label = document.createElement("label");
+    render_buffer_label.className = "ssv-label";
+    render_buffer_label.innerText = "Render Buffer:"
+
+    const render_buffer_input = document.createElement("input");
+    render_buffer_input.className = "ssv-input-number";
+    render_buffer_input.type = "number";
+    render_buffer_input.min = "0";
+    render_buffer_input.step = "1";
+    render_buffer_input.valueAsNumber = 0;
+    render_buffer_input.onchange = () => {
+      this._save_image_settings.render_buffer = render_buffer_input.valueAsNumber;
+    }
+    render_buffer_span.append(render_buffer_label, render_buffer_input);
+    this._settings_panel_element.appendChild(render_buffer_span);
+  }
+}
+
+export {SSVWidgetSaveImageSettingsPanel}

--- a/src/widget_status_bar.ts
+++ b/src/widget_status_bar.ts
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2024 Thomas Mathieson.
+ * Distributed under the terms of the MIT license.
+ */
+
+import {RENDERDOC_LOGO_SVG} from "./renderdoc_logo";
+import {SSVWidgetSaveImageSettingsPanel} from "./widget_save_image_settings";
+import {DOMWidgetView} from "@jupyter-widgets/base";
+
+class SSVStatusBarView {
+  private _widget_view: DOMWidgetView;
+  private _widget_root_element: HTMLElement;
+  private _stream_element: HTMLImageElement | HTMLCanvasElement | null;
+  private _status_frame_stats_element: HTMLButtonElement | null = null;
+  private _show_advanced_status: boolean = false;
+  private _status_adv_frame_stats_element: HTMLTableCellElement[] = [];
+  private _status_resolution_element: HTMLSpanElement | null = null;
+  private _log_button_element: HTMLButtonElement | null = null;
+  private _log_element: HTMLElement | null = null;
+  private _save_settings_panel: SSVWidgetSaveImageSettingsPanel;
+
+  public constructor(widget: DOMWidgetView, root: HTMLElement,
+                     stream_element: HTMLImageElement | HTMLCanvasElement | null) {
+    this._widget_view = widget;
+    this._widget_root_element = root;
+    this._stream_element = stream_element;
+    this._save_settings_panel = new SSVWidgetSaveImageSettingsPanel(widget, root);
+  }
+
+  public render() {
+    const status_bar_div = document.createElement("div");
+    status_bar_div.className = "ssv-status-bar";
+    this._widget_root_element.appendChild(status_bar_div);
+
+    // Play + Stop buttons
+    this.render_playback_controls(status_bar_div);
+    // Frame statistics (FPS counter)
+    this.render_frame_stats_control(status_bar_div);
+    // Canvas resolution
+    this.render_canvas_resolution_control(status_bar_div);
+    // Connection status
+    this.render_connection_status_control(status_bar_div);
+    // Renderdoc capture button
+    this.render_renderdoc_capture_control(status_bar_div);
+    // Save image button
+    this.render_image_save_control(status_bar_div);
+    // View Logs button
+    this.render_view_logs_control(status_bar_div);
+
+
+    // Log panel
+    this.render_log_panel();
+  }
+
+  public slow_update() {
+    if (this._status_frame_stats_element) {
+      if (this._show_advanced_status) {
+        const times_str: string = this._widget_view.model.get("frame_times");
+        const times = times_str.split(";");
+        if (times.length >= 4 && this._status_adv_frame_stats_element.length == 4) {
+          this._status_adv_frame_stats_element[0].innerText = times[0];
+          this._status_adv_frame_stats_element[1].innerText = times[1];
+          this._status_adv_frame_stats_element[2].innerText = times[2];
+          this._status_adv_frame_stats_element[3].innerText = times[3];
+        }
+      } else {
+        this._status_frame_stats_element.innerText = `${this._widget_view.model.get("frame_rate").toFixed(2)} FPS`;
+      }
+    }
+    if (this._status_resolution_element) {
+      this._status_resolution_element.innerText = `${this._stream_element?.width ?? 0} x ${this._stream_element?.height ?? 0}`;
+    }
+  }
+
+  private render_playback_controls(status_bar_div: HTMLDivElement) {
+    const status_play_pause = document.createElement("span");
+    status_play_pause.className = "ssv-status-play-pause";
+    status_bar_div.appendChild(status_play_pause);
+    const play_button = document.createElement("button");
+    play_button.textContent = "⏵";
+    play_button.className = "ssv-button ssv-icon-button";
+    play_button.onclick = () => {
+      this._widget_view.send({"play": 0})
+    };
+    status_play_pause.appendChild(play_button);
+    const stop_button = document.createElement("button");
+    stop_button.textContent = "⏹︎";
+    stop_button.className = "ssv-button ssv-icon-button";
+    stop_button.onclick = () => {
+      this._widget_view.send({"stop": 0})
+    };
+    status_play_pause.appendChild(stop_button);
+  }
+
+  private render_frame_stats_control(status_bar_div: HTMLDivElement) {
+    const status_frame_stats = document.createElement("span");
+    status_frame_stats.className = "ssv-status-frame-stats";
+    status_bar_div.appendChild(status_frame_stats);
+    const frame_status_button = document.createElement("button");
+    this._status_frame_stats_element = frame_status_button;
+    frame_status_button.textContent = "? FPS";
+    frame_status_button.className = "ssv-button";
+    status_frame_stats.appendChild(frame_status_button);
+    frame_status_button.onclick = () => {
+      const show_advanced = !this._show_advanced_status;
+      if (this._status_frame_stats_element) {
+        if (!this._show_advanced_status) {
+          // Create the advanced frame stats table
+          const table = document.createElement("table");
+          const tbody = document.createElement("tbody");
+          table.appendChild(tbody);
+          table.className = "ssv-status-frame-stats";
+          const r1 = document.createElement("tr");
+          const r2 = document.createElement("tr");
+          tbody.append(r1, r2);
+          tbody.className = "ssv-status-frame-stats";
+          const c1 = document.createElement("td");
+          const c2 = document.createElement("td");
+          const c3 = document.createElement("td");
+          const c4 = document.createElement("td");
+          c1.className = "ssv-status-frame-stats";
+          c2.className = "ssv-status-frame-stats";
+          c3.className = "ssv-status-frame-stats";
+          c4.className = "ssv-status-frame-stats";
+          r1.append(c1, c2);
+          r2.append(c3, c4);
+          this._status_adv_frame_stats_element = [c1, c2, c3, c4];
+          this._status_frame_stats_element.innerText = "";
+          this._status_frame_stats_element.appendChild(table);
+        } else {
+          // Remove the advanced frame stats table
+          const table = this._status_frame_stats_element.firstChild;
+          this._status_adv_frame_stats_element = [];
+          if (table)
+            this._status_frame_stats_element.removeChild(table);
+        }
+      }
+      this._show_advanced_status = show_advanced;
+    };
+  }
+
+  private render_canvas_resolution_control(status_bar_div: HTMLDivElement) {
+    const status_resolution = document.createElement("span");
+    status_resolution.className = "ssv-status-resolution";
+    status_bar_div.appendChild(status_resolution);
+    this._status_resolution_element = status_resolution;
+  }
+
+  private render_connection_status_control(status_bar_div: HTMLDivElement) {
+    const status_connection = document.createElement("span");
+    status_connection.className = "ssv-status-connection";
+    status_connection.innerText = "⭮ Connecting";
+    status_bar_div.appendChild(status_connection);
+    this._widget_view.model.on("change:status_connection", () => {
+      if (this._widget_view.model.get("status_connection")) {
+        status_connection.innerText = "🗲 Connected";
+        status_connection.classList.toggle("ssv-status-disconnected", false);
+      } else {
+        status_connection.innerText = "✕ Disconnected";
+        status_connection.classList.toggle("ssv-status-disconnected", true);
+      }
+    }, this);
+  }
+
+  private render_renderdoc_capture_control(status_bar_div: HTMLDivElement) {
+    const renderdoc_capture = document.createElement("span");
+    renderdoc_capture.className = "ssv-status-renderdoc";
+    status_bar_div.appendChild(renderdoc_capture);
+    const capture_button = document.createElement("button");
+    capture_button.innerHTML = RENDERDOC_LOGO_SVG;
+    capture_button.className = "ssv-button ssv-icon-button";
+    renderdoc_capture.appendChild(capture_button);
+    capture_button.style.visibility = this._widget_view.model.get("enable_renderdoc") ? "visible" : "hidden";
+    capture_button.onclick = () => {
+      this._widget_view.send({"renderdoc_capture": 0})
+    };
+    this._widget_view.model.on("change:enable_renderdoc", () => {
+      capture_button.style.visibility = this._widget_view.model.get("enable_renderdoc") ? "visible" : "hidden";
+    });
+  }
+
+  private render_image_save_control(status_bar_div: HTMLDivElement) {
+    const save_image_controls = document.createElement("span");
+    save_image_controls.className = "ssv-status-save-image";
+    status_bar_div.appendChild(save_image_controls);
+    const save_image_button = document.createElement("button");
+    save_image_button.textContent = "📷";
+    save_image_button.className = "ssv-button ssv-icon-button ssv-combi-button-left";
+    save_image_button.onclick = () => {
+      this._widget_view.send({"save_image": this._save_settings_panel.save_image_settings})
+    };
+    save_image_controls.appendChild(save_image_button);
+    const save_image_settings_button = document.createElement("button");
+    save_image_settings_button.textContent = "⚙️";
+    save_image_settings_button.className = "ssv-button ssv-icon-button ssv-combi-button-right";
+    save_image_settings_button.onclick = () => {
+      this._save_settings_panel.hidden = !this._save_settings_panel.hidden;
+    };
+    save_image_controls.appendChild(save_image_settings_button);
+
+    this._save_settings_panel.render(save_image_controls);
+  }
+
+  private render_view_logs_control(status_bar_div: HTMLDivElement) {
+    const status_log = document.createElement("span");
+    status_log.className = "ssv-status-log";
+    status_bar_div.appendChild(status_log);
+    const log_button = document.createElement("button");
+    this._log_button_element = log_button;
+    log_button.textContent = "View Log";
+    log_button.className = "ssv-button";
+    status_log.appendChild(log_button);
+    log_button.onclick = () => {
+      if (this._log_element) {
+        const active = this._log_element.classList.toggle("ssv-log-active");
+        if (active)
+          log_button.textContent = "Hide Log";
+        else
+          log_button.textContent = "View Log";
+      }
+    };
+  }
+
+  private render_log_panel() {
+    const log_div = document.createElement("code");
+    log_div.className = "ssv-log";
+    this._widget_root_element.appendChild(log_div);
+    this._log_element = log_div;
+    this._widget_view.model.on("change:status_logs", () => {
+      if (this._log_element) {
+        let log_text: string = this._widget_view.model.get("status_logs");
+        log_text = log_text.replace(/\r\n|\r|\n/g, '<br>');
+        log_text = log_text.replace(/\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;');
+        if (log_text.includes("[WARNING]")) {
+          log_text = "<span class='ssv-log-warn'>" + log_text + "</span>";
+          if (this._log_button_element)
+            this._log_button_element.textContent += " ⚠️";
+        } else if (log_text.includes("[ERROR]")) {
+          log_text = "<span class='ssv-log-error'>" + log_text + "</span>";
+          if (this._log_button_element)
+            this._log_button_element.textContent += " ⛔";
+        }
+
+        // Work out if we need to auto-scroll to the bottom of the log.
+        // If the scroll position is within 150 pixels of the bottom, then we keep auto-scrolling.
+        const auto_scroll = this._log_element.scrollHeight == this._log_element.clientHeight ||
+          (this._log_element.scrollHeight - this._log_element.scrollTop - this._log_element.clientHeight) <= 150;
+
+        // You would have to be pretty determined to use this as an XSS entrypoint
+        this._log_element.innerHTML = this._log_element.innerHTML + log_text;
+
+        if (auto_scroll)
+          this._log_element.scrollTo({top: this._log_element.scrollHeight, behavior: "instant"});
+      }
+    }, this);
+  }
+}
+
+export {SSVStatusBarView};


### PR DESCRIPTION
 - Documented global_uniforms.glsl
 - Bumped packaged version
 - Pinned clang version to 14 so that RTD builds
 - Added getter for frame number
 - The renderer start time can now be set
 - This allows the canvas time to be get/set in the SSVCanvas
 - Added dedicated pause/unpause methods
 - ssv_render_opengl.py will now attempt to create an EGL context on linux if creating an X11 context failed
 - The render process client no longer sets the process start method on Google Collab; I think it was breaking things?
 - Image saving